### PR TITLE
fix: Use mutable class only if required

### DIFF
--- a/patches/src/main/kotlin/patches/bandcamp/ShowSearchResultScoresPatch.kt
+++ b/patches/src/main/kotlin/patches/bandcamp/ShowSearchResultScoresPatch.kt
@@ -10,13 +10,18 @@ import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
 import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
 import com.android.tools.smali.dexlib2.iface.reference.MethodReference
 import com.android.tools.smali.dexlib2.iface.reference.StringReference
+import patches.universal.ads.util.findMutableMethodOf
 import java.util.logging.Logger
 
 private fun BytecodePatchContext.foldShowSearchResultScore(): Int {
     var patched = 0
     classDefForEach { classDef ->
-        val mutableClass = mutableClassDefBy(classDef)
-        for (method in mutableClass.methods) {
+        // Must create mutable classes/methods only if required to prevent out of memory errors.
+        val mutableClass by lazy { mutableClassDefBy(classDef) }
+        for (method in classDef.methods) {
+            val mutableMethod by lazy {
+                mutableClass.findMutableMethodOf(method)
+            }
             val impl = method.implementation ?: continue
             val instructions = impl.instructions.toList()
             for ((index, insn) in instructions.withIndex()) {
@@ -60,12 +65,12 @@ private fun BytecodePatchContext.foldShowSearchResultScore(): Int {
                 val next = instructions.getOrNull(index + 1)
                 if (next != null && next.opcode == Opcode.MOVE_RESULT) {
                     val resReg = (next as OneRegisterInstruction).registerA
-                    method.replaceInstruction(index, "const/4 v$resReg, 0x1")
-                    method.replaceInstruction(index + 1, "nop")
+                    mutableMethod.replaceInstruction(index, "const/4 v$resReg, 0x1")
+                    mutableMethod.replaceInstruction(index + 1, "nop")
                     patched++
                 } else if (next == null || next.opcode != Opcode.MOVE_RESULT) {
                     // no move-result (unused)  -  just nop the invoke
-                    method.replaceInstruction(index, "nop")
+                    mutableMethod.replaceInstruction(index, "nop")
                     patched++
                 }
             }

--- a/patches/src/main/kotlin/patches/universal/ads/AdsFreeRewardsPatch.kt
+++ b/patches/src/main/kotlin/patches/universal/ads/AdsFreeRewardsPatch.kt
@@ -2,11 +2,12 @@ package patches.universal.ads
 
 import app.morphe.patcher.extensions.InstructionExtensions.addInstructions
 import app.morphe.patcher.extensions.InstructionExtensions.removeInstructions
+import app.morphe.patcher.patch.BytecodePatchContext
 import app.morphe.patcher.patch.booleanOption
 import app.morphe.patcher.patch.bytecodePatch
 import app.morphe.patcher.patch.stringOption
-import app.morphe.patcher.patch.BytecodePatchContext
-import patches.universal.ads.util.cloneMutableAndPreserveParameters
+import patches.universal.ads.util.cloneParameters
+import patches.universal.ads.util.findMutableMethodOf
 import patches.universal.ads.util.fireRewardedAdCallbacks
 import java.util.logging.Logger
 
@@ -196,8 +197,8 @@ private fun BytecodePatchContext.applyAdsFreeRewardsV1190(logger: Logger, reward
     if (useHuawei && instantReward == true && huaweiReady != null && huaweiShow != null) {
         val showClass = HuaweiRewardAdShowFingerprint.classDefOrNull
         if (showClass != null) {
-            val clonedShow = huaweiShow.cloneMutableAndPreserveParameters(showClass)
-            clonedShow.addInstructions(0, """
+            huaweiShow.cloneParameters().addInstructions(
+                0, """
                 if-eqz p2, :morphe_huawei_reward_done
                 invoke-virtual {p2}, Lcom/huawei/hms/ads/reward/RewardAdStatusListener;->onRewardAdOpened()V
                 sget-object v0, Lcom/huawei/hms/ads/reward/Reward;->DEFAULT:Lcom/huawei/hms/ads/reward/Reward;
@@ -205,7 +206,8 @@ private fun BytecodePatchContext.applyAdsFreeRewardsV1190(logger: Logger, reward
                 invoke-virtual {p2}, Lcom/huawei/hms/ads/reward/RewardAdStatusListener;->onRewardAdClosed()V
                 :morphe_huawei_reward_done
                 return-void
-            """.trimIndent())
+            """.trimIndent()
+            )
             logger.info("Huawei Ads Kit rewarded patch succeeded")
         } else {
             logger.warning("Ads Free Rewards: Huawei show class not found  -  skipping")
@@ -240,9 +242,8 @@ private fun BytecodePatchContext.applyMyTargetStrategy(logger: Logger) {
         logger.warning("Ads Free Rewards: skip MyTarget  -  low registerCount")
         return
     }
-    val showClass = MyTargetBaseInterstitialShowFingerprint.classDefOrNull ?: return
-    val cloned = myTargetShow.cloneMutableAndPreserveParameters(showClass)
-    cloned.addInstructions(0, """
+    myTargetShow.cloneParameters().addInstructions(
+        0, """
         instance-of v0, p0, Lcom/my/target/ads/RewardedAd;
         if-eqz v0, :morphe_rustore_mytarget_original_show
         check-cast p0, Lcom/my/target/ads/RewardedAd;
@@ -257,7 +258,8 @@ private fun BytecodePatchContext.applyMyTargetStrategy(logger: Logger) {
         :morphe_rustore_mytarget_done
         return-void
         :morphe_rustore_mytarget_original_show
-    """.trimIndent())
+    """.trimIndent()
+    )
     logger.info("Ads Free Rewards: RuStore / VK MyTarget rewarded patch succeeded")
 }
 
@@ -273,8 +275,7 @@ private fun BytecodePatchContext.applyYandexWrapperStrategy(logger: Logger) {
         :morphe_rustore_yandex_reward_done
         return-void
     """.trimIndent())
-    val showClass = YandexUnityRewardedWrapperShowFingerprint.classDefOrNull ?: return
-    val clonedShow = yandexRewardedShow.cloneMutableAndPreserveParameters(showClass)
+    val clonedShow = yandexRewardedShow.cloneParameters()
     // Replace the original method instead of prepending to it. Yandex's wrapper
     // can contain branch targets that become invalid when instructions are
     // inserted before its existing implementation, causing VerifyError at runtime.
@@ -337,9 +338,8 @@ private fun BytecodePatchContext.applyIronSourceAdsWrapperStrategy(logger: Logge
             const/4 v0, 0x1
             return v0
         """.trimIndent())
-        val showClass = IronSourceAdsRewardedShowPreciseFingerprint.classDefOrNull ?: return
-        val cloned = show.cloneMutableAndPreserveParameters(showClass)
-        cloned.addInstructions(0, """
+        show.cloneParameters().addInstructions(
+            0, """
             invoke-virtual {p0}, Lcom/unity3d/ironsourceads/rewarded/RewardedAd;->getListener()Lcom/unity3d/ironsourceads/rewarded/RewardedAdListener;
             move-result-object v0
             if-eqz v0, :morphe_isads_done
@@ -348,7 +348,8 @@ private fun BytecodePatchContext.applyIronSourceAdsWrapperStrategy(logger: Logge
             invoke-interface {v0, p0}, Lcom/unity3d/ironsourceads/rewarded/RewardedAdListener;->onRewardedAdDismissed(Lcom/unity3d/ironsourceads/rewarded/RewardedAd;)V
             :morphe_isads_done
             return-void
-        """.trimIndent())
+        """.trimIndent()
+        )
         logger.info("Ads Free Rewards: ironSourceAds wrapper patch succeeded (instant reward)")
     } catch (e: Exception) {
         logger.warning("Ads Free Rewards: ironSourceAds wrapper patch failed: ${e.message}")
@@ -377,9 +378,8 @@ private fun BytecodePatchContext.applyMadsStrategy(logger: Logger, useIronSource
         return
     }
     try {
-        val showClass = MadsWrapperShowAdFingerprint.classDefOrNull ?: return
-        val cloned = show.cloneMutableAndPreserveParameters(showClass)
-        cloned.addInstructions(0, """
+        show.cloneParameters().addInstructions(
+            0, """
             sget-object v0, Lcom/miniclip/madsunityplugin/utils/MAdsSDKWrapperUtils${'$'}MAdsWrapperAdFormat;->RewardedVideos:Lcom/miniclip/madsunityplugin/utils/MAdsSDKWrapperUtils${'$'}MAdsWrapperAdFormat;
             iget v0, v0, Lcom/miniclip/madsunityplugin/utils/MAdsSDKWrapperUtils${'$'}MAdsWrapperAdFormat;->id:I
             if-ne p1, v0, :morphe_mads_original
@@ -397,23 +397,22 @@ private fun BytecodePatchContext.applyMadsStrategy(logger: Logger, useIronSource
             const/4 v0, 0x1
             return v0
             :morphe_mads_original
-        """.trimIndent())
+        """.trimIndent()
+        )
         logger.info("Ads Free Rewards: MADS patch succeeded (instant reward)")
         val ready = MadsWrapperIsReadyFingerprint.methodOrNull
         if (ready != null) {
-            val readyClass = MadsWrapperIsReadyFingerprint.classDefOrNull
-            if (readyClass != null) {
-                val clonedReady = ready.cloneMutableAndPreserveParameters(readyClass)
-                clonedReady.addInstructions(0, """
-                    sget-object v0, Lcom/miniclip/madsunityplugin/utils/MAdsSDKWrapperUtils${'$'}MAdsWrapperAdFormat;->RewardedVideos:Lcom/miniclip/madsunityplugin/utils/MAdsSDKWrapperUtils${'$'}MAdsWrapperAdFormat;
-                    iget v0, v0, Lcom/miniclip/madsunityplugin/utils/MAdsSDKWrapperUtils${'$'}MAdsWrapperAdFormat;->id:I
-                    if-ne p1, v0, :morphe_mads_ready_original
-                    const/4 v0, 0x1
-                    return v0
-                    :morphe_mads_ready_original
-                """.trimIndent())
-                logger.info("Ads Free Rewards: MADS patch succeeded (fake ready)")
-            }
+            ready.cloneParameters().addInstructions(
+                0, """
+                sget-object v0, Lcom/miniclip/madsunityplugin/utils/MAdsSDKWrapperUtils${'$'}MAdsWrapperAdFormat;->RewardedVideos:Lcom/miniclip/madsunityplugin/utils/MAdsSDKWrapperUtils${'$'}MAdsWrapperAdFormat;
+                iget v0, v0, Lcom/miniclip/madsunityplugin/utils/MAdsSDKWrapperUtils${'$'}MAdsWrapperAdFormat;->id:I
+                if-ne p1, v0, :morphe_mads_ready_original
+                const/4 v0, 0x1
+                return v0
+                :morphe_mads_ready_original
+            """.trimIndent()
+            )
+            logger.info("Ads Free Rewards: MADS patch succeeded (fake ready)")
         }
     } catch (e: Exception) {
         logger.warning("Ads Free Rewards: MADS patch failed: ${e.message}")
@@ -430,9 +429,8 @@ private fun BytecodePatchContext.applyMaxUnityStrategy(logger: Logger, useMax: B
         return v0
     """.trimIndent())
     if (instantReward == true) {
-        val showClass = ShowRewardedAdFingerprint.classDefOrNull ?: return true
-        val clonedShow = unityShow.cloneMutableAndPreserveParameters(showClass)
-        clonedShow.addInstructions(0, """
+        unityShow.cloneParameters().addInstructions(
+            0, """
             move-object v0, p1
             new-instance p0, Lorg/json/JSONObject;
             invoke-direct {p0}, Lorg/json/JSONObject;-><init>()V
@@ -474,13 +472,13 @@ private fun BytecodePatchContext.applyMaxUnityStrategy(logger: Logger, useMax: B
             invoke-static {p0, p1, p2}, Lcom/applovin/impl/sdk/utils/JsonUtils;->putString(Lorg/json/JSONObject;Ljava/lang/String;Ljava/lang/String;)V
             invoke-static {p0}, Lcom/applovin/mediation/unity/MaxUnityAdManager;->forwardUnityEvent(Lorg/json/JSONObject;)V
             return-void
-        """.trimIndent())
+        """.trimIndent()
+        )
         val unityLoad = LoadRewardedAdFingerprint.methodOrNull
         if (unityLoad != null) {
             logger.info("Ads Free Rewards: MAX Unity loadRewardedAd patching")
-            val loadClass = LoadRewardedAdFingerprint.classDefOrNull ?: return true
-            val clonedLoad = unityLoad.cloneMutableAndPreserveParameters(loadClass)
-            clonedLoad.addInstructions(0, """
+            unityLoad.cloneParameters().addInstructions(
+                0, """
                 move-object v0, p1
                 new-instance p0, Lorg/json/JSONObject;
                 invoke-direct {p0}, Lorg/json/JSONObject;-><init>()V
@@ -494,7 +492,8 @@ private fun BytecodePatchContext.applyMaxUnityStrategy(logger: Logger, useMax: B
                 invoke-static {p0, p1, v1}, Lcom/applovin/impl/sdk/utils/JsonUtils;->putString(Lorg/json/JSONObject;Ljava/lang/String;Ljava/lang/String;)V
                 invoke-static {p0}, Lcom/applovin/mediation/unity/MaxUnityAdManager;->forwardUnityEvent(Lorg/json/JSONObject;)V
                 return-void
-            """.trimIndent())
+            """.trimIndent()
+            )
         }
     }
     return true
@@ -514,17 +513,12 @@ private fun BytecodePatchContext.applyNativeMaxStrategy(logger: Logger, useMax: 
         if (rc >= 7) {
             nativeShow.addInstructions(0, fireRewardedAdCallbacks())
         } else {
-            val showClass = MaxRewardedAdShowAdFingerprint.classDefOrNull
-            if (showClass != null) {
-                try {
-                    val cloned = nativeShow.cloneMutableAndPreserveParameters(showClass)
-                    cloned.addInstructions(0, fireRewardedAdCallbacks())
-                    logger.info("Ads Free Rewards: native MAX via clone (low regs $rc)")
-                } catch (e: Exception) {
-                    logger.warning("Ads Free Rewards: clone failed for native MAX: ${e.message}")
-                }
-            } else {
-                logger.warning("Ads Free Rewards: skip native MAX showAd()  -  registerCount $rc < 7")
+            try {
+                nativeShow.cloneParameters()
+                    .addInstructions(0, fireRewardedAdCallbacks())
+                logger.info("Ads Free Rewards: native MAX via clone (low regs $rc)")
+            } catch (e: Exception) {
+                logger.warning("Ads Free Rewards: clone failed for native MAX: ${e.message}")
             }
         }
     }
@@ -537,8 +531,12 @@ private fun BytecodePatchContext.applyAdMobRewardedStrategy(logger: Logger, useM
     classDefForEach { classDef ->
         val tl = classDef.type.lowercase()
         if (tl.contains("okhttp") || tl.contains("androidx") || tl.contains("com/google/android/gms/ads/rewarded")) return@classDefForEach
-        val mutableClass = try { mutableClassDefBy(classDef) } catch (_: Exception) { return@classDefForEach }
-        for (method in mutableClass.methods) {
+        // Must create mutable classes/methods only if required to prevent out of memory errors.
+        val mutableClass by lazy { mutableClassDefBy(classDef) }
+        for (method in classDef.methods) {
+            val mutableMethod by lazy {
+                mutableClass.findMutableMethodOf(method)
+            }
             val impl = method.implementation ?: continue
             val instructions = impl.instructions.toList()
             for ((index, insn) in instructions.withIndex()) {
@@ -565,7 +563,7 @@ private fun BytecodePatchContext.applyAdMobRewardedStrategy(logger: Logger, useM
                         }
                         else -> continue
                     }
-                    method.addInstructions(index, """
+                    mutableMethod.addInstructions(index, """
                         if-eqz v$listenerReg, :morphe_admob_skip_$index
                         const/4 v0, 0x0
                         invoke-interface {v$listenerReg, v0}, Lcom/google/android/gms/ads/OnUserEarnedRewardListener;->onUserEarnedReward(Lcom/google/android/gms/ads/rewarded/RewardItem;)V

--- a/patches/src/main/kotlin/patches/universal/ads/AdsFreeRewardsVersions.kt
+++ b/patches/src/main/kotlin/patches/universal/ads/AdsFreeRewardsVersions.kt
@@ -2,7 +2,7 @@ package patches.universal.ads
 
 import app.morphe.patcher.extensions.InstructionExtensions.addInstructions
 import app.morphe.patcher.patch.BytecodePatchContext
-import patches.universal.ads.util.cloneMutableAndPreserveParameters
+import patches.universal.ads.util.cloneParameters
 import patches.universal.ads.util.fireRewardedAdCallbacks
 import java.util.logging.Logger
 
@@ -849,12 +849,11 @@ internal fun BytecodePatchContext.applyAdsFreeRewardsV1181(logger: Logger) {
         // Uses JsonUtils.putString (avoids JSONException), then calls
         // forwardUnityEvent to push through the MAX SDK callback pipeline.
         // The method is cloned with extra registers that hold copies of the
-        // parameters (see BytecodeUtils.cloneMutableAndPreserveParameters),
+        // parameters (see BytecodeUtils.cloneParameters),
         // so the injection only uses v0 + p0/p1/p2 and works with ANY
         // register layout (e.g. .registers 3 like Crowd Champs' showAd path).
-        val showClass = ShowRewardedAdFingerprint.classDefOrNull
-        val clonedShow = unityShow.cloneMutableAndPreserveParameters(showClass!!)
-        clonedShow.addInstructions(0, """
+        unityShow.cloneParameters().addInstructions(
+            0, """
             move-object v0, p1
             new-instance p0, Lorg/json/JSONObject;
             invoke-direct {p0}, Lorg/json/JSONObject;-><init>()V
@@ -896,7 +895,8 @@ internal fun BytecodePatchContext.applyAdsFreeRewardsV1181(logger: Logger) {
             invoke-static {p0, p1, p2}, Lcom/applovin/impl/sdk/utils/JsonUtils;->putString(Lorg/json/JSONObject;Ljava/lang/String;Ljava/lang/String;)V
             invoke-static {p0}, Lcom/applovin/mediation/unity/MaxUnityAdManager;->forwardUnityEvent(Lorg/json/JSONObject;)V
             return-void
-        """.trimIndent())
+        """.trimIndent()
+        )
 
         // Patch loadRewardedAd to fire OnRewardedAdLoadedEvent via forwardUnityEvent.
         // When the game C# IL2CPP side calls MaxSdk.LoadRewardedAd() and subscribes to
@@ -909,9 +909,8 @@ internal fun BytecodePatchContext.applyAdsFreeRewardsV1181(logger: Logger) {
         val unityLoad = LoadRewardedAdFingerprint.methodOrNull
         if (unityLoad != null) {
             logger.info("MAX Unity loadRewardedAd patching")
-            val loadClass = LoadRewardedAdFingerprint.classDefOrNull
-            val clonedLoad = unityLoad.cloneMutableAndPreserveParameters(loadClass!!)
-            clonedLoad.addInstructions(0, """
+            unityLoad.cloneParameters().addInstructions(
+                0, """
                 move-object v0, p1
                 new-instance p0, Lorg/json/JSONObject;
                 invoke-direct {p0}, Lorg/json/JSONObject;-><init>()V
@@ -925,7 +924,8 @@ internal fun BytecodePatchContext.applyAdsFreeRewardsV1181(logger: Logger) {
                 invoke-static {p0, p1, v1}, Lcom/applovin/impl/sdk/utils/JsonUtils;->putString(Lorg/json/JSONObject;Ljava/lang/String;Ljava/lang/String;)V
                 invoke-static {p0}, Lcom/applovin/mediation/unity/MaxUnityAdManager;->forwardUnityEvent(Lorg/json/JSONObject;)V
                 return-void
-            """.trimIndent())
+            """.trimIndent()
+            )
         }
         return
     }

--- a/patches/src/main/kotlin/patches/universal/ads/NoAdsPatch.kt
+++ b/patches/src/main/kotlin/patches/universal/ads/NoAdsPatch.kt
@@ -2,14 +2,15 @@ package patches.universal.ads
 
 import app.morphe.patcher.Fingerprint
 import app.morphe.patcher.extensions.InstructionExtensions.addInstructions
+import app.morphe.patcher.patch.BytecodePatchContext
 import app.morphe.patcher.patch.booleanOption
 import app.morphe.patcher.patch.bytecodePatch
-import app.morphe.patcher.patch.BytecodePatchContext
 import app.morphe.patcher.patch.stringOption
 import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
-import java.util.logging.Logger
-import patches.universal.ads.util.cloneMutableAndPreserveParameters
+import patches.universal.ads.util.cloneParameters
+import patches.universal.ads.util.findMutableMethodOf
 import patches.universal.ads.util.fireHiddenCallbacks
+import java.util.logging.Logger
 
 private val logger = Logger.getLogger("patches.universal.ads.NoAdsPatch")
 
@@ -71,7 +72,7 @@ private fun BytecodePatchContext.patchVoid(fingerprint: Fingerprint): Int {
                 if (!isAd) continue
             }
             val mutableClass = mutableClassDefByOrNull(classDef.type) ?: return@classDefForEach
-            val mutableMethod = mutableClass.methods.find { it.name == name && it.returnType == ret && it.parameterTypes.map { p -> p.toString() } == params } ?: return@classDefForEach
+            val mutableMethod = mutableClass.findMutableMethodOf(m)
             if (mutableMethod.implementation == null) return@classDefForEach
             mutableMethod.addInstructions(0, "return-void")
             patched++
@@ -111,7 +112,7 @@ private fun BytecodePatchContext.patchReturnFalse(fingerprint: Fingerprint): Int
                 if (!isAd) continue
             }
             val mutableClass = mutableClassDefByOrNull(classDef.type) ?: return@classDefForEach
-            val mutableMethod = mutableClass.methods.find { it.name == name && it.returnType == ret && it.parameterTypes.map { p -> p.toString() } == params } ?: return@classDefForEach
+            val mutableMethod = mutableClass.findMutableMethodOf(m)
             if (mutableMethod.implementation == null) return@classDefForEach
             mutableMethod.addInstructions(0, "const/4 v0, 0x0\nreturn v0")
             patched++
@@ -126,16 +127,12 @@ private fun BytecodePatchContext.patchWith(fingerprint: Fingerprint, smali: Stri
     if (exact != null && exact.implementation != null) {
         val rc = exact.implementation?.registerCount ?: 0
         if ((fingerprint === MaxInterstitialAdShowAdFingerprint || fingerprint === MaxAppOpenAdShowAdFingerprint || fingerprint === MaxRewardedAdShowAdFingerprint) && rc < 7) {
-            val classDef = fingerprint.classDefOrNull
-            if (classDef != null) {
-                try {
-                    val cloned = exact.cloneMutableAndPreserveParameters(classDef)
-                    cloned.addInstructions(0, smali)
-                    logger.info("No Ads: patched ${fingerprint.name} via clone (low regs $rc) in ${exact.definingClass}")
-                    return 1
-                } catch (e: Exception) {
-                    logger.warning("No Ads: clone failed for ${fingerprint.name}: ${e.message}")
-                }
+            try {
+                exact.cloneParameters().addInstructions(0, smali)
+                logger.info("No Ads: patched ${fingerprint.name} via clone (low regs $rc) in ${exact.definingClass}")
+                return 1
+            } catch (e: Exception) {
+                logger.warning("No Ads: clone failed for ${fingerprint.name}: ${e.message}")
             }
             logger.warning("No Ads: skipping ${fingerprint.name} in ${exact.definingClass}: register count $rc < 7")
             return 0
@@ -593,17 +590,20 @@ val noAdsPatch = bytecodePatch(
             if (!tl.contains("song") && !tl.contains("station") && !tl.contains("stream") && !tl.contains("ad")) return@classDefForEach
             if (tl.contains("okhttp") || tl.contains("androidx")) return@classDefForEach
             try {
-                val mutableClass = mutableClassDefBy(classDef)
-                for (method in mutableClass.methods) {
+                val mutableClass by lazy { mutableClassDefBy(classDef) }
+                for (method in classDef.methods) {
+                    val mutableMethod by lazy {
+                        mutableClass.findMutableMethodOf(method)
+                    }
                     val n = method.name.lowercase()
                     val isAdToken = n.contains("adsidentitytoken") || n.contains("adsresponse") || n.contains("adsduration") || n.contains("cuepoints") || n.contains("adsid")
                     if (!isAdToken) continue
                     try {
                         if (method.returnType == "Ljava/lang/String;" && method.implementation != null) {
-                            method.addInstructions(0, "const-string v0, \"\"\nreturn-object v0")
+                            mutableMethod.addInstructions(0, "const-string v0, \"\"\nreturn-object v0")
                             totalPatched++
                         } else if ((method.returnType.contains("List") || method.returnType.contains("Collection")) && method.implementation != null) {
-                            method.addInstructions(0, "invoke-static {}, Ljava/util/Collections;->emptyList()Ljava/util/List;\nmove-result-object v0\nreturn-object v0")
+                            mutableMethod.addInstructions(0, "invoke-static {}, Ljava/util/Collections;->emptyList()Ljava/util/List;\nmove-result-object v0\nreturn-object v0")
                             totalPatched++
                         }
                     } catch (_: Exception) {}

--- a/patches/src/main/kotlin/patches/universal/ads/util/BytecodeUtils.kt
+++ b/patches/src/main/kotlin/patches/universal/ads/util/BytecodeUtils.kt
@@ -1,14 +1,79 @@
+/*
+ * Copyright 2025 Morphe.
+ * https://github.com/MorpheApp/morphe-patches-library
+ *
+ * File-Specific License Notice (GPLv3 Section 7 Terms)
+ *
+ * This file is part of the Morphe project and is licensed under
+ * the GNU General Public License version 3 (GPLv3), with the Additional
+ * Terms under Section 7 described in the LICENSE file.
+ *
+ * https://www.gnu.org/licenses/gpl-3.0.html
+ *
+ * Section 7b: Notice Preservation
+ * -------------------------------
+ * This entire comment block must be preserved in all copies,
+ * distributions, and derivative works of this file, in both
+ * original and modified source forms.
+ *
+ * Portions of this software are provided "AS IS" by the Morphe software project.
+ * Any express or implied warranties, including the implied warranties of
+ * merchantability and fitness for a particular purpose, are disclaimed.
+ */
+
 package patches.universal.ads.util
 
 import app.morphe.patcher.extensions.InstructionExtensions.addInstructions
+import app.morphe.patcher.patch.BytecodePatchContext
 import app.morphe.patcher.util.proxy.mutableTypes.MutableClass
 import app.morphe.patcher.util.proxy.mutableTypes.MutableMethod
 import app.morphe.patcher.util.proxy.mutableTypes.MutableMethod.Companion.toMutable
 import com.android.tools.smali.dexlib2.AccessFlags
 import com.android.tools.smali.dexlib2.iface.Method
 import com.android.tools.smali.dexlib2.iface.MethodParameter
+import com.android.tools.smali.dexlib2.iface.instruction.FiveRegisterInstruction
+import com.android.tools.smali.dexlib2.iface.instruction.Instruction
+import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
+import com.android.tools.smali.dexlib2.iface.instruction.RegisterRangeInstruction
+import com.android.tools.smali.dexlib2.iface.instruction.ThreeRegisterInstruction
+import com.android.tools.smali.dexlib2.iface.instruction.TwoRegisterInstruction
+import com.android.tools.smali.dexlib2.iface.reference.MethodReference
 import com.android.tools.smali.dexlib2.immutable.ImmutableMethod
 import com.android.tools.smali.dexlib2.immutable.ImmutableMethodImplementation
+import com.android.tools.smali.dexlib2.util.MethodUtil
+
+/**
+ * Find the [MutableMethod] from a given [Method] in a [MutableClass].
+ *
+ * @param method The [Method] to find.
+ * @return The [MutableMethod].
+ */
+fun MutableClass.findMutableMethodOf(method: MethodReference) = this.methods.first {
+    MethodUtil.methodSignaturesMatch(it, method)
+}
+
+/**
+ * @return The registers used by this instruction.
+ */
+val Instruction.registersUsed: List<Int>
+    get() = when (this) {
+        is FiveRegisterInstruction -> {
+            when (registerCount) {
+                0 -> listOf()
+                1 -> listOf(registerC)
+                2 -> listOf(registerC, registerD)
+                3 -> listOf(registerC, registerD, registerE)
+                4 -> listOf(registerC, registerD, registerE, registerF)
+                else -> listOf(registerC, registerD, registerE, registerF, registerG)
+            }
+        }
+
+        is ThreeRegisterInstruction -> listOf(registerA, registerB, registerC)
+        is TwoRegisterInstruction -> listOf(registerA, registerB)
+        is OneRegisterInstruction -> listOf(registerA)
+        is RegisterRangeInstruction -> (startRegister until (startRegister + registerCount)).toList()
+        else -> emptyList()
+    }
 
 /**
  * @return The number of registers for all parameters, including p0.
@@ -72,7 +137,8 @@ val Method.p0Register: Int
  * Added registers always start at index: `originalMethod.implementation!!.registerCount` of the
  * original uncloned method.
  *
- * **Fingerprint match indexes will be increased positively by [additionalRegisters]**.
+ * **Fingerprint match indexes will be increased positively by
+ * [numberOfParameterRegistersLogical] of the cloned method**.
  */
 fun Method.cloneMutable(
     name: String = this.name,
@@ -117,7 +183,7 @@ fun Method.cloneMutable(
 
             // Handle `this`.
             if (isNotStatic) {
-                addInstructions(insertIndex++, "move-object/from16 v$destReg, p$pReg")
+                addInstructions(insertIndex++, "move-object/from16 v$destReg, p0")
                 addedInstructions++
                 destReg += 1
                 pReg += 1
@@ -161,10 +227,10 @@ fun Method.cloneMutable(
  * Added registers always start at index: `originalMethod.implementation!!.registerCount` of the
  * original uncloned method.
  *
- * **Fingerprint match indexes will be increased positively by [numberOfParameterRegisters]**.
+ * **Fingerprint match indexes will be increased positively by [numberOfParameterRegistersLogical]**.
  */
-fun Method.cloneMutableAndPreserveParameters(mutableClass: MutableClass): MutableMethod {
-    check(!AccessFlags.STATIC.isSet(accessFlags) || parameters.isNotEmpty()) {
+fun Method.cloneParameters(mutableClass : MutableClass) : MutableMethod {
+    check (!AccessFlags.STATIC.isSet(accessFlags) || parameters.isNotEmpty()) {
         "Static methods have no parameter registers to preserve"
     }
 
@@ -174,9 +240,22 @@ fun Method.cloneMutableAndPreserveParameters(mutableClass: MutableClass): Mutabl
 
     // Replace existing method with cloned with more registers.
     mutableClass.methods.apply {
-        remove(this@cloneMutableAndPreserveParameters)
+        remove(this@cloneParameters)
         add(clonedMethod)
     }
 
     return clonedMethod
 }
+
+/**
+ * Additional registers effectively take the place of the pX parameters (p0, p1, p2, etc.)
+ * and contain the original contents of the method parameters.
+ * Added registers always start at index: `originalMethod.implementation!!.registerCount` of the
+ * original uncloned method.
+ *
+ * **Fingerprint match indexes will be increased positively by [numberOfParameterRegistersLogical]**.
+ */
+context(patchContext: BytecodePatchContext)
+fun Method.cloneParameters() = cloneParameters(
+    patchContext.mutableClassDefBy(definingClass)
+)

--- a/patches/src/main/kotlin/patches/universal/graphics/FrameRatePreferencePatch.kt
+++ b/patches/src/main/kotlin/patches/universal/graphics/FrameRatePreferencePatch.kt
@@ -3,8 +3,8 @@ package patches.universal.graphics
 import app.morphe.patcher.extensions.InstructionExtensions.addInstructions
 import app.morphe.patcher.patch.bytecodePatch
 import app.morphe.patcher.patch.stringOption
+import patches.universal.ads.util.cloneParameters
 import java.util.logging.Logger
-import patches.universal.ads.util.cloneMutableAndPreserveParameters
 
 private val frameRateBits = mapOf(
     "24" to "0x41c00000",
@@ -75,8 +75,7 @@ val frameRatePreferencePatch = bytecodePatch(
         var patched = 0
         classDefForEach { classDef ->
             if (!isActivity(classDef.type)) return@classDefForEach
-            val mutableClass = mutableClassDefBy(classDef)
-            val methods = mutableClass.methods.toList()
+            val methods = classDef.methods.toList()
             for (matchedMethod in methods) {
                 if (matchedMethod.name != "onCreate" ||
                     matchedMethod.returnType != "V" ||
@@ -87,8 +86,7 @@ val frameRatePreferencePatch = bytecodePatch(
                 }
 
                 // Add temporary registers while preserving p0 (the Activity) and p1 (Bundle).
-                val method = matchedMethod.cloneMutableAndPreserveParameters(mutableClass)
-                method.addInstructions(
+                matchedMethod.cloneParameters().addInstructions(
                     0,
                     """
                     sget v0, Landroid/os/Build${'$'}VERSION;->SDK_INT:I

--- a/patches/src/main/kotlin/patches/universal/graphics/GraphicsApiOverridePatch.kt
+++ b/patches/src/main/kotlin/patches/universal/graphics/GraphicsApiOverridePatch.kt
@@ -4,7 +4,7 @@ import app.morphe.patcher.extensions.InstructionExtensions.addInstructions
 import app.morphe.patcher.patch.bytecodePatch
 import app.morphe.patcher.patch.stringOption
 import java.util.logging.Logger
-import patches.universal.ads.util.cloneMutableAndPreserveParameters
+import patches.universal.ads.util.cloneParameters
 
 @Suppress("unused")
 val graphicsApiOverridePatch = bytecodePatch(
@@ -43,7 +43,7 @@ val graphicsApiOverridePatch = bytecodePatch(
 
         // v0..v2 may overlap p0/p1 in a small onCreate method. Add registers and
         // preserve the original parameters before using them as temporaries.
-        val method = matchedMethod.cloneMutableAndPreserveParameters(mutableClass)
+        val method = matchedMethod.cloneParameters(mutableClass)
         if ((method.implementation?.registerCount ?: 0) < 3) {
             logger.warning("Unity activity could not provide 3 temporary registers. No changes applied.")
             return@execute

--- a/patches/src/main/kotlin/patches/universal/misc/AllowMixedContentPatch.kt
+++ b/patches/src/main/kotlin/patches/universal/misc/AllowMixedContentPatch.kt
@@ -3,13 +3,12 @@ package patches.universal.misc
 import app.morphe.patcher.extensions.InstructionExtensions.replaceInstruction
 import app.morphe.patcher.patch.bytecodePatch
 import com.android.tools.smali.dexlib2.Opcode
-import com.android.tools.smali.dexlib2.iface.instruction.FiveRegisterInstruction
-import com.android.tools.smali.dexlib2.iface.instruction.Instruction
 import com.android.tools.smali.dexlib2.iface.instruction.NarrowLiteralInstruction
 import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
 import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
-import com.android.tools.smali.dexlib2.iface.instruction.RegisterRangeInstruction
 import com.android.tools.smali.dexlib2.iface.reference.MethodReference
+import patches.universal.ads.util.findMutableMethodOf
+import patches.universal.ads.util.registersUsed
 import java.util.logging.Logger
 
 @Suppress("unused")
@@ -22,8 +21,13 @@ val allowMixedContentPatch = bytecodePatch(
         val logger = Logger.getLogger(this::class.java.name)
         var patched = 0
         classDefForEach { classDef ->
-            val mutableClass = mutableClassDefBy(classDef)
-            for (method in mutableClass.methods) {
+            val mutableClass by lazy { mutableClassDefBy(classDef) }
+
+            for (method in classDef.methods) {
+                val mutableMethod by lazy {
+                    mutableClass.findMutableMethodOf(method)
+                }
+
                 val impl = method.implementation ?: continue
                 val instructions = impl.instructions.toList()
                 for ((index, insn) in instructions.withIndex()) {
@@ -33,11 +37,7 @@ val allowMixedContentPatch = bytecodePatch(
                     if (ref.name != "setMixedContentMode" || ref.returnType != "V") continue
                     if (ref.parameterTypes != listOf("I")) continue
 
-                    val reg = when (insn) {
-                        is FiveRegisterInstruction -> insn.registerC
-                        is RegisterRangeInstruction -> insn.startRegister + insn.registerCount - 1
-                        else -> continue
-                    }
+                    val reg = insn.registersUsed[0]
 
                     for (j in index - 1 downTo 0) {
                         val prev = instructions[j]
@@ -46,7 +46,7 @@ val allowMixedContentPatch = bytecodePatch(
                             prev is OneRegisterInstruction &&
                             prev.registerA == reg
                         ) {
-                            method.replaceInstruction(j, "const/4 v$reg, 0x1")
+                            mutableMethod.replaceInstruction(j, "const/4 v$reg, 0x1")
                             patched++
                             break
                         }

--- a/patches/src/main/kotlin/patches/universal/misc/AllowTextSelectionPatch.kt
+++ b/patches/src/main/kotlin/patches/universal/misc/AllowTextSelectionPatch.kt
@@ -10,6 +10,7 @@ import com.android.tools.smali.dexlib2.iface.instruction.NarrowLiteralInstructio
 import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
 import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
 import com.android.tools.smali.dexlib2.iface.reference.MethodReference
+import patches.universal.ads.util.findMutableMethodOf
 import java.util.logging.Logger
 
 /**
@@ -28,8 +29,11 @@ val allowTextSelectionPatch = bytecodePatch(
         val logger = Logger.getLogger(this::class.java.name)
         var patched = 0
         classDefForEach { classDef ->
-            val mutableClass = mutableClassDefBy(classDef)
-            for (method in mutableClass.methods) {
+            val mutableClass by lazy { mutableClassDefBy(classDef) }
+            for (method in classDef.methods) {
+                val mutableMethod by lazy {
+                    mutableClass.findMutableMethodOf(method)
+                }
                 val implementation = method.implementation ?: continue
                 // Snapshot; one-for-one replacements keep indices valid.
                 val instructions: List<Instruction> = implementation.instructions.toList()
@@ -66,7 +70,7 @@ val allowTextSelectionPatch = bytecodePatch(
                             // Already enabled (or a different value); leave it.
                             break
                         }
-                        method.replaceInstruction(j, "const/4 v$argRegister, 0x1")
+                        mutableMethod.replaceInstruction(j, "const/4 v$argRegister, 0x1")
                         patched++
                         break
                     }

--- a/patches/src/main/kotlin/patches/universal/misc/AllowWebViewAutoplayPatch.kt
+++ b/patches/src/main/kotlin/patches/universal/misc/AllowWebViewAutoplayPatch.kt
@@ -4,13 +4,12 @@ import app.morphe.patcher.extensions.InstructionExtensions.replaceInstruction
 import app.morphe.patcher.patch.BytecodePatchContext
 import app.morphe.patcher.patch.bytecodePatch
 import com.android.tools.smali.dexlib2.Opcode
-import com.android.tools.smali.dexlib2.iface.instruction.FiveRegisterInstruction
-import com.android.tools.smali.dexlib2.iface.instruction.Instruction
 import com.android.tools.smali.dexlib2.iface.instruction.NarrowLiteralInstruction
 import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
 import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
-import com.android.tools.smali.dexlib2.iface.instruction.RegisterRangeInstruction
 import com.android.tools.smali.dexlib2.iface.reference.MethodReference
+import patches.universal.ads.util.findMutableMethodOf
+import patches.universal.ads.util.registersUsed
 import java.util.logging.Logger
 
 private fun BytecodePatchContext.forceBooleanSetter(
@@ -21,8 +20,11 @@ private fun BytecodePatchContext.forceBooleanSetter(
     val literal = if (value) "0x1" else "0x0"
     var patched = 0
     classDefForEach { classDef ->
-        val mutableClass = mutableClassDefBy(classDef)
-        for (method in mutableClass.methods) {
+        val mutableClass by lazy { mutableClassDefBy(classDef) }
+        for (method in classDef.methods) {
+            val mutableMethod by lazy {
+                mutableClass.findMutableMethodOf(method)
+            }
             val impl = method.implementation ?: continue
             val instructions = impl.instructions.toList()
             for ((index, insn) in instructions.withIndex()) {
@@ -33,12 +35,7 @@ private fun BytecodePatchContext.forceBooleanSetter(
                 if (ref.returnType != "V") continue
                 if (ref.parameterTypes != listOf("Z")) continue
 
-                val reg = when (insn) {
-                    is FiveRegisterInstruction -> insn.registerD
-                    is RegisterRangeInstruction -> insn.startRegister + insn.registerCount - 1
-                    else -> continue
-                }
-
+                val reg = insn.registersUsed[1]
                 for (j in index - 1 downTo 0) {
                     val prev = instructions[j]
                     if (prev.opcode == Opcode.NOP) continue
@@ -46,7 +43,7 @@ private fun BytecodePatchContext.forceBooleanSetter(
                         prev is OneRegisterInstruction &&
                         prev.registerA == reg
                     ) {
-                        method.replaceInstruction(j, "const/4 v$reg, $literal")
+                        mutableMethod.replaceInstruction(j, "const/4 v$reg, $literal")
                         patched++
                         break
                     }

--- a/patches/src/main/kotlin/patches/universal/misc/AllowWebViewFileAccessPatch.kt
+++ b/patches/src/main/kotlin/patches/universal/misc/AllowWebViewFileAccessPatch.kt
@@ -4,13 +4,12 @@ import app.morphe.patcher.extensions.InstructionExtensions.replaceInstruction
 import app.morphe.patcher.patch.BytecodePatchContext
 import app.morphe.patcher.patch.bytecodePatch
 import com.android.tools.smali.dexlib2.Opcode
-import com.android.tools.smali.dexlib2.iface.instruction.FiveRegisterInstruction
-import com.android.tools.smali.dexlib2.iface.instruction.Instruction
 import com.android.tools.smali.dexlib2.iface.instruction.NarrowLiteralInstruction
 import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
 import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
-import com.android.tools.smali.dexlib2.iface.instruction.RegisterRangeInstruction
 import com.android.tools.smali.dexlib2.iface.reference.MethodReference
+import patches.universal.ads.util.findMutableMethodOf
+import patches.universal.ads.util.registersUsed
 import java.util.logging.Logger
 
 private fun BytecodePatchContext.forceBooleanSetter(
@@ -21,8 +20,11 @@ private fun BytecodePatchContext.forceBooleanSetter(
     val literal = if (value) "0x1" else "0x0"
     var patched = 0
     classDefForEach { classDef ->
-        val mutableClass = mutableClassDefBy(classDef)
-        for (method in mutableClass.methods) {
+        val mutableClass by lazy { mutableClassDefBy(classDef) }
+        for (method in classDef.methods) {
+            val mutableMethod by lazy {
+                mutableClass.findMutableMethodOf(method)
+            }
             val impl = method.implementation ?: continue
             val instructions = impl.instructions.toList()
             for ((index, insn) in instructions.withIndex()) {
@@ -33,12 +35,7 @@ private fun BytecodePatchContext.forceBooleanSetter(
                 if (ref.returnType != "V") continue
                 if (ref.parameterTypes != listOf("Z")) continue
 
-                val reg = when (insn) {
-                    is FiveRegisterInstruction -> insn.registerD
-                    is RegisterRangeInstruction -> insn.startRegister + insn.registerCount - 1
-                    else -> continue
-                }
-
+                val reg = insn.registersUsed[1]
                 for (j in index - 1 downTo 0) {
                     val prev = instructions[j]
                     if (prev.opcode == Opcode.NOP) continue
@@ -46,7 +43,7 @@ private fun BytecodePatchContext.forceBooleanSetter(
                         prev is OneRegisterInstruction &&
                         prev.registerA == reg
                     ) {
-                        method.replaceInstruction(j, "const/4 v$reg, $literal")
+                        mutableMethod.replaceInstruction(j, "const/4 v$reg, $literal")
                         patched++
                         break
                     }

--- a/patches/src/main/kotlin/patches/universal/misc/BypassEmulatorDetectionPatch.kt
+++ b/patches/src/main/kotlin/patches/universal/misc/BypassEmulatorDetectionPatch.kt
@@ -6,14 +6,13 @@ import app.morphe.patcher.patch.booleanOption
 import app.morphe.patcher.patch.bytecodePatch
 import app.morphe.patcher.patch.stringOption
 import com.android.tools.smali.dexlib2.Opcode
-import com.android.tools.smali.dexlib2.builder.instruction.BuilderInstruction35c
-import com.android.tools.smali.dexlib2.builder.instruction.BuilderInstruction3rc
 import com.android.tools.smali.dexlib2.iface.instruction.Instruction
 import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
 import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
 import com.android.tools.smali.dexlib2.iface.reference.FieldReference
 import com.android.tools.smali.dexlib2.iface.reference.MethodReference
 import com.android.tools.smali.dexlib2.iface.reference.StringReference
+import patches.universal.ads.util.findMutableMethodOf
 import patches.universal.ui.StartupHooks.escapeSmali
 import java.util.logging.Logger
 
@@ -47,8 +46,11 @@ private val BUILD_STRING_FIELDS = setOf(
 internal fun BytecodePatchContext.foldBuildStringFields(values: Map<String, String>): Int {
     var patched = 0
     classDefForEach { classDef ->
-        val mutableClass = mutableClassDefBy(classDef)
-        for (method in mutableClass.methods) {
+        val mutableClass by lazy { mutableClassDefBy(classDef) }
+        for (method in classDef.methods) {
+            val mutableMethod by lazy {
+                mutableClass.findMutableMethodOf(method)
+            }
             val implementation = method.implementation ?: continue
             val instructions: List<Instruction> = implementation.instructions.toList()
             for ((index, instruction) in instructions.withIndex()) {
@@ -61,7 +63,7 @@ internal fun BytecodePatchContext.foldBuildStringFields(values: Map<String, Stri
                 val value = values[reference.name] ?: continue
 
                 val register = (instruction as? OneRegisterInstruction)?.registerA ?: continue
-                method.replaceInstruction(
+                mutableMethod.replaceInstruction(
                     index,
                     "const-string v$register, \"${escapeSmali(value)}\"",
                 )
@@ -80,8 +82,11 @@ internal fun BytecodePatchContext.foldBuildStringFields(values: Map<String, Stri
 internal fun BytecodePatchContext.foldBuildGetSerial(value: String): Int {
     var patched = 0
     classDefForEach { classDef ->
-        val mutableClass = mutableClassDefBy(classDef)
-        for (method in mutableClass.methods) {
+        val mutableClass by lazy { mutableClassDefBy(classDef) }
+        for (method in classDef.methods) {
+            val mutableMethod by lazy {
+                mutableClass.findMutableMethodOf(method)
+            }
             val implementation = method.implementation ?: continue
             val instructions: List<Instruction> = implementation.instructions.toList()
             for ((index, instruction) in instructions.withIndex()) {
@@ -97,10 +102,10 @@ internal fun BytecodePatchContext.foldBuildGetSerial(value: String): Int {
                     (next.opcode == Opcode.MOVE_RESULT ||
                         next.opcode == Opcode.MOVE_RESULT_OBJECT)
                 ) {
-                    method.replaceInstruction(index, "const-string v$register, \"${escapeSmali(value)}\"")
-                    method.replaceInstruction(index + 1, "nop")
+                    mutableMethod.replaceInstruction(index, "const-string v$register, \"${escapeSmali(value)}\"")
+                    mutableMethod.replaceInstruction(index + 1, "nop")
                 } else {
-                    method.replaceInstruction(index, "nop")
+                    mutableMethod.replaceInstruction(index, "nop")
                 }
                 patched++
             }
@@ -123,8 +128,11 @@ internal fun BytecodePatchContext.foldBuildGetSerial(value: String): Int {
 internal fun BytecodePatchContext.foldSystemPropertyMap(properties: Map<String, String>): Int {
     var patched = 0
     classDefForEach { classDef ->
-        val mutableClass = mutableClassDefBy(classDef)
-        for (method in mutableClass.methods) {
+        val mutableClass by lazy { mutableClassDefBy(classDef) }
+        for (method in classDef.methods) {
+            val mutableMethod by lazy {
+                mutableClass.findMutableMethodOf(method)
+            }
             val implementation = method.implementation ?: continue
             val instructions: List<Instruction> = implementation.instructions.toList()
             for ((index, instruction) in instructions.withIndex()) {
@@ -151,10 +159,10 @@ internal fun BytecodePatchContext.foldSystemPropertyMap(properties: Map<String, 
                     (next.opcode == Opcode.MOVE_RESULT ||
                         next.opcode == Opcode.MOVE_RESULT_OBJECT)
                 ) {
-                    method.replaceInstruction(index, "const-string v$register, \"${escapeSmali(value)}\"")
-                    method.replaceInstruction(index + 1, "nop")
+                    mutableMethod.replaceInstruction(index, "const-string v$register, \"${escapeSmali(value)}\"")
+                    mutableMethod.replaceInstruction(index + 1, "nop")
                 } else {
-                    method.replaceInstruction(index, "nop")
+                    mutableMethod.replaceInstruction(index, "nop")
                 }
                 patched++
             }
@@ -177,8 +185,11 @@ internal fun BytecodePatchContext.foldQemuProperties(properties: Set<String>, va
 internal fun BytecodePatchContext.foldBuildMethodResult(methodName: String, value: String): Int {
     var patched = 0
     classDefForEach { classDef ->
-        val mutableClass = mutableClassDefBy(classDef)
-        for (method in mutableClass.methods) {
+        val mutableClass by lazy { mutableClassDefBy(classDef) }
+        for (method in classDef.methods) {
+            val mutableMethod by lazy {
+                mutableClass.findMutableMethodOf(method)
+            }
             val implementation = method.implementation ?: continue
             val instructions: List<Instruction> = implementation.instructions.toList()
             for ((index, instruction) in instructions.withIndex()) {
@@ -195,10 +206,10 @@ internal fun BytecodePatchContext.foldBuildMethodResult(methodName: String, valu
                     (next.opcode == Opcode.MOVE_RESULT ||
                         next.opcode == Opcode.MOVE_RESULT_OBJECT)
                 ) {
-                    method.replaceInstruction(index, "const-string v$register, \"${escapeSmali(value)}\"")
-                    method.replaceInstruction(index + 1, "nop")
+                    mutableMethod.replaceInstruction(index, "const-string v$register, \"${escapeSmali(value)}\"")
+                    mutableMethod.replaceInstruction(index + 1, "nop")
                 } else {
-                    method.replaceInstruction(index, "nop")
+                    mutableMethod.replaceInstruction(index, "nop")
                 }
                 patched++
             }
@@ -220,8 +231,11 @@ internal fun BytecodePatchContext.foldBuildGetRadioVersion(value: String): Int =
 internal fun BytecodePatchContext.foldPhoneType(value: Int): Int {
     var patched = 0
     classDefForEach { classDef ->
-        val mutableClass = mutableClassDefBy(classDef)
-        for (method in mutableClass.methods) {
+        val mutableClass by lazy { mutableClassDefBy(classDef) }
+        for (method in classDef.methods) {
+            val mutableMethod by lazy {
+                mutableClass.findMutableMethodOf(method)
+            }
             val implementation = method.implementation ?: continue
             val instructions: List<Instruction> = implementation.instructions.toList()
             for ((index, instruction) in instructions.withIndex()) {
@@ -238,10 +252,10 @@ internal fun BytecodePatchContext.foldPhoneType(value: Int): Int {
                     (next.opcode == Opcode.MOVE_RESULT ||
                         next.opcode == Opcode.MOVE_RESULT_OBJECT)
                 ) {
-                    method.replaceInstruction(index, "const/4 v$register, ${value.and(0xf)}")
-                    method.replaceInstruction(index + 1, "nop")
+                    mutableMethod.replaceInstruction(index, "const/4 v$register, ${value.and(0xf)}")
+                    mutableMethod.replaceInstruction(index + 1, "nop")
                 } else {
-                    method.replaceInstruction(index, "nop")
+                    mutableMethod.replaceInstruction(index, "nop")
                 }
                 patched++
             }

--- a/patches/src/main/kotlin/patches/universal/misc/BypassHostnameVerificationPatch.kt
+++ b/patches/src/main/kotlin/patches/universal/misc/BypassHostnameVerificationPatch.kt
@@ -2,6 +2,7 @@ package patches.universal.misc
 
 import app.morphe.patcher.extensions.InstructionExtensions.addInstruction
 import app.morphe.patcher.patch.bytecodePatch
+import patches.universal.ads.util.findMutableMethodOf
 import java.util.logging.Logger
 
 @Suppress("unused")
@@ -15,14 +16,17 @@ val bypassHostnameVerificationPatch = bytecodePatch(
         var patched = 0
         classDefForEach { classDef ->
             if (classDef.interfaces.none { it == "Ljavax/net/ssl/HostnameVerifier;" }) return@classDefForEach
-            val mutableClass = mutableClassDefBy(classDef)
-            for (method in mutableClass.methods) {
+            val mutableClass by lazy { mutableClassDefBy(classDef) }
+            for (method in classDef.methods) {
+                val mutableMethod by lazy {
+                    mutableClass.findMutableMethodOf(method)
+                }
                 val impl = method.implementation ?: continue
                 if (method.returnType != "Z") continue
                 if (method.name != "verify") continue
                 if (method.parameterTypes != listOf("Ljava/lang/String;", "Ljavax/net/ssl/SSLSession;")) continue
-                method.addInstruction(0, "const/4 v0, 0x1")
-                method.addInstruction(1, "return v0")
+                mutableMethod.addInstruction(0, "const/4 v0, 0x1")
+                mutableMethod.addInstruction(1, "return v0")
                 patched++
             }
         }

--- a/patches/src/main/kotlin/patches/universal/misc/BypassOkHttpPinningPatch.kt
+++ b/patches/src/main/kotlin/patches/universal/misc/BypassOkHttpPinningPatch.kt
@@ -2,6 +2,7 @@ package patches.universal.misc
 
 import app.morphe.patcher.extensions.InstructionExtensions.addInstruction
 import app.morphe.patcher.patch.bytecodePatch
+import patches.universal.ads.util.findMutableMethodOf
 import java.util.logging.Logger
 
 /** OkHttp2/OkHttp3 CertificatePinner variants. */
@@ -28,14 +29,15 @@ val bypassOkHttpPinningPatch = bytecodePatch(
         classDefForEach { classDef ->
             if (pinnerClasses.none { classDef.type.startsWith(it) }) return@classDefForEach
 
-            val mutableClass = mutableClassDefBy(classDef)
-            for (method in mutableClass.methods) {
+            val mutableClass by lazy { mutableClassDefBy(classDef) }
+            for (method in classDef.methods) {
                 // Only void check methods are touched; they throw instead of returning values,
                 // so an immediate return disables rejection entirely.
                 if (method.returnType != "V") continue
                 if (method.name !in checkMethods) continue
 
-                method.addInstruction(0, "return-void")
+                mutableClass.findMutableMethodOf(method)
+                    .addInstruction(0, "return-void")
                 patched++
             }
         }

--- a/patches/src/main/kotlin/patches/universal/misc/BypassVpnDetectionPatch.kt
+++ b/patches/src/main/kotlin/patches/universal/misc/BypassVpnDetectionPatch.kt
@@ -6,6 +6,7 @@ import com.android.tools.smali.dexlib2.Opcode
 import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
 import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
 import com.android.tools.smali.dexlib2.iface.reference.MethodReference
+import patches.universal.ads.util.findMutableMethodOf
 import java.util.logging.Logger
 
 @Suppress("unused")
@@ -33,8 +34,11 @@ val bypassVpnDetectionPatch = bytecodePatch(
 
         var patched = 0
         classDefForEach { classDef ->
-            val mutableClass = mutableClassDefBy(classDef)
-            for (method in mutableClass.methods) {
+            val mutableClass by lazy { mutableClassDefBy(classDef) }
+            for (method in classDef.methods) {
+                val mutableMethod by lazy {
+                    mutableClass.findMutableMethodOf(method)
+                }
                 val implementation = method.implementation ?: continue
                 // Snapshot; one-for-one replacements keep indices valid.
                 val instructions = implementation.instructions.toList()
@@ -46,10 +50,10 @@ val bypassVpnDetectionPatch = bytecodePatch(
 
                     val next = instructions.getOrNull(index + 1) as? OneRegisterInstruction
                     if (next != null && next.opcode == Opcode.MOVE_RESULT) {
-                        method.replaceInstruction(index, "const/4 v${next.registerA}, $value")
-                        method.replaceInstruction(index + 1, "nop")
+                        mutableMethod.replaceInstruction(index, "const/4 v${next.registerA}, $value")
+                        mutableMethod.replaceInstruction(index + 1, "nop")
                     } else {
-                        method.replaceInstruction(index, "nop")
+                        mutableMethod.replaceInstruction(index, "nop")
                     }
                     patched++
                 }

--- a/patches/src/main/kotlin/patches/universal/misc/BypassWebViewSafeBrowsingPatch.kt
+++ b/patches/src/main/kotlin/patches/universal/misc/BypassWebViewSafeBrowsingPatch.kt
@@ -4,10 +4,10 @@ import app.morphe.patcher.extensions.InstructionExtensions.replaceInstruction
 import app.morphe.patcher.patch.BytecodePatchContext
 import app.morphe.patcher.patch.bytecodePatch
 import com.android.tools.smali.dexlib2.iface.instruction.FiveRegisterInstruction
-import com.android.tools.smali.dexlib2.iface.instruction.Instruction
 import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
 import com.android.tools.smali.dexlib2.iface.instruction.RegisterRangeInstruction
 import com.android.tools.smali.dexlib2.iface.reference.MethodReference
+import patches.universal.ads.util.findMutableMethodOf
 import java.util.logging.Logger
 
 private fun BytecodePatchContext.replaceVoidCallsWithProceed(
@@ -17,8 +17,11 @@ private fun BytecodePatchContext.replaceVoidCallsWithProceed(
 ): Int {
     var patched = 0
     classDefForEach { classDef ->
-        val mutableClass = mutableClassDefBy(classDef)
-        for (method in mutableClass.methods) {
+        val mutableClass by lazy { mutableClassDefBy(classDef) }
+        for (method in classDef.methods) {
+            val mutableMethod by lazy {
+                mutableClass.findMutableMethodOf(method)
+            }
             val impl = method.implementation ?: continue
             val instructions = impl.instructions.toList()
             for ((index, insn) in instructions.withIndex()) {
@@ -33,7 +36,7 @@ private fun BytecodePatchContext.replaceVoidCallsWithProceed(
                     is RegisterRangeInstruction -> insn.startRegister
                     else -> continue
                 }
-                method.replaceInstruction(index, "invoke-virtual {v$objReg}, $targetClass->proceed()V")
+                mutableMethod.replaceInstruction(index, "invoke-virtual {v$objReg}, $targetClass->proceed()V")
                 patched++
             }
         }

--- a/patches/src/main/kotlin/patches/universal/misc/BypassWebViewSslErrorsPatch.kt
+++ b/patches/src/main/kotlin/patches/universal/misc/BypassWebViewSslErrorsPatch.kt
@@ -4,10 +4,10 @@ import app.morphe.patcher.extensions.InstructionExtensions.replaceInstruction
 import app.morphe.patcher.patch.BytecodePatchContext
 import app.morphe.patcher.patch.bytecodePatch
 import com.android.tools.smali.dexlib2.iface.instruction.FiveRegisterInstruction
-import com.android.tools.smali.dexlib2.iface.instruction.Instruction
 import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
 import com.android.tools.smali.dexlib2.iface.instruction.RegisterRangeInstruction
 import com.android.tools.smali.dexlib2.iface.reference.MethodReference
+import patches.universal.ads.util.findMutableMethodOf
 import java.util.logging.Logger
 
 private fun BytecodePatchContext.replaceVoidCallsWithProceed(
@@ -17,8 +17,11 @@ private fun BytecodePatchContext.replaceVoidCallsWithProceed(
 ): Int {
     var patched = 0
     classDefForEach { classDef ->
-        val mutableClass = mutableClassDefBy(classDef)
-        for (method in mutableClass.methods) {
+        val mutableClass by lazy { mutableClassDefBy(classDef) }
+        for (method in classDef.methods) {
+            val mutableMethod by lazy {
+                mutableClass.findMutableMethodOf(method)
+            }
             val impl = method.implementation ?: continue
             val instructions = impl.instructions.toList()
             for ((index, insn) in instructions.withIndex()) {
@@ -33,7 +36,7 @@ private fun BytecodePatchContext.replaceVoidCallsWithProceed(
                     is RegisterRangeInstruction -> insn.startRegister
                     else -> continue
                 }
-                method.replaceInstruction(index, "invoke-virtual {v$objReg}, $targetClass->proceed()V")
+                mutableMethod.replaceInstruction(index, "invoke-virtual {v$objReg}, $targetClass->proceed()V")
                 patched++
             }
         }

--- a/patches/src/main/kotlin/patches/universal/misc/DisableLogcatLoggingPatch.kt
+++ b/patches/src/main/kotlin/patches/universal/misc/DisableLogcatLoggingPatch.kt
@@ -7,6 +7,7 @@ import com.android.tools.smali.dexlib2.Opcode
 import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
 import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
 import com.android.tools.smali.dexlib2.iface.reference.MethodReference
+import patches.universal.ads.util.findMutableMethodOf
 import java.util.logging.Logger
 
 @Suppress("unused")
@@ -37,8 +38,11 @@ val disableLogcatLoggingPatch = bytecodePatch(
         }
         var patched = 0
         classDefForEach { classDef ->
-            val mutableClass = mutableClassDefBy(classDef)
-            for (method in mutableClass.methods) {
+            val mutableClass by lazy { mutableClassDefBy(classDef) }
+            for (method in classDef.methods) {
+                val mutableMethod by lazy {
+                    mutableClass.findMutableMethodOf(method)
+                }
                 val impl = method.implementation ?: continue
                 val instructions = impl.instructions.toList()
                 for ((index, insn) in instructions.withIndex()) {
@@ -50,8 +54,8 @@ val disableLogcatLoggingPatch = bytecodePatch(
                     if (ref.returnType == "I" && next != null && next.opcode == Opcode.MOVE_RESULT) {
                         val resultRegister = (next as OneRegisterInstruction).registerA
                         val constInstr = if (resultRegister <= 0xf) "const/4 v$resultRegister, 0x0" else "const/16 v$resultRegister, 0x0"
-                        method.replaceInstruction(index, constInstr)
-                        method.replaceInstruction(index + 1, "nop")
+                        mutableMethod.replaceInstruction(index, constInstr)
+                        mutableMethod.replaceInstruction(index + 1, "nop")
                     } else if (next != null && (next.opcode == Opcode.MOVE_RESULT_OBJECT || next.opcode == Opcode.MOVE_RESULT_WIDE)) {
                         val resultRegister = (next as OneRegisterInstruction).registerA
                         val constInstr = if (next.opcode == Opcode.MOVE_RESULT_WIDE) {
@@ -59,10 +63,10 @@ val disableLogcatLoggingPatch = bytecodePatch(
                         } else {
                             if (resultRegister <= 0xff) "const/4 v$resultRegister, 0x0" else "const/16 v$resultRegister, 0x0"
                         }
-                        method.replaceInstruction(index, constInstr)
-                        method.replaceInstruction(index + 1, "nop")
+                        mutableMethod.replaceInstruction(index, constInstr)
+                        mutableMethod.replaceInstruction(index + 1, "nop")
                     } else {
-                        method.replaceInstruction(index, "nop")
+                        mutableMethod.replaceInstruction(index, "nop")
                     }
                     patched++
                 }

--- a/patches/src/main/kotlin/patches/universal/misc/DisableSecureSurfacesPatch.kt
+++ b/patches/src/main/kotlin/patches/universal/misc/DisableSecureSurfacesPatch.kt
@@ -4,13 +4,12 @@ import app.morphe.patcher.extensions.InstructionExtensions.replaceInstruction
 import app.morphe.patcher.patch.BytecodePatchContext
 import app.morphe.patcher.patch.bytecodePatch
 import com.android.tools.smali.dexlib2.Opcode
-import com.android.tools.smali.dexlib2.iface.instruction.FiveRegisterInstruction
-import com.android.tools.smali.dexlib2.iface.instruction.Instruction
 import com.android.tools.smali.dexlib2.iface.instruction.NarrowLiteralInstruction
 import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
 import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
-import com.android.tools.smali.dexlib2.iface.instruction.RegisterRangeInstruction
 import com.android.tools.smali.dexlib2.iface.reference.MethodReference
+import patches.universal.ads.util.findMutableMethodOf
+import patches.universal.ads.util.registersUsed
 import java.util.logging.Logger
 
 private fun BytecodePatchContext.forceBooleanSetter(
@@ -21,8 +20,11 @@ private fun BytecodePatchContext.forceBooleanSetter(
     val literal = if (value) "0x1" else "0x0"
     var patched = 0
     classDefForEach { classDef ->
-        val mutableClass = mutableClassDefBy(classDef)
-        for (method in mutableClass.methods) {
+        val mutableClass by lazy { mutableClassDefBy(classDef) }
+        for (method in classDef.methods) {
+            val mutableMethod by lazy {
+                mutableClass.findMutableMethodOf(method)
+            }
             val impl = method.implementation ?: continue
             val instructions = impl.instructions.toList()
             for ((index, insn) in instructions.withIndex()) {
@@ -33,11 +35,7 @@ private fun BytecodePatchContext.forceBooleanSetter(
                 if (ref.returnType != "V") continue
                 if (ref.parameterTypes != listOf("Z")) continue
 
-                val reg = when (insn) {
-                    is FiveRegisterInstruction -> insn.registerD
-                    is RegisterRangeInstruction -> insn.startRegister + insn.registerCount - 1
-                    else -> continue
-                }
+                val reg = insn.registersUsed[1]
 
                 for (j in index - 1 downTo 0) {
                     val prev = instructions[j]
@@ -46,7 +44,7 @@ private fun BytecodePatchContext.forceBooleanSetter(
                         prev is OneRegisterInstruction &&
                         prev.registerA == reg
                     ) {
-                        method.replaceInstruction(j, "const/4 v$reg, $literal")
+                        mutableMethod.replaceInstruction(j, "const/4 v$reg, $literal")
                         patched++
                         break
                     }

--- a/patches/src/main/kotlin/patches/universal/misc/DisableStrictModePatch.kt
+++ b/patches/src/main/kotlin/patches/universal/misc/DisableStrictModePatch.kt
@@ -4,6 +4,7 @@ import app.morphe.patcher.extensions.InstructionExtensions.replaceInstruction
 import app.morphe.patcher.patch.bytecodePatch
 import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
 import com.android.tools.smali.dexlib2.iface.reference.MethodReference
+import patches.universal.ads.util.findMutableMethodOf
 import java.util.logging.Logger
 
 @Suppress("unused")
@@ -21,8 +22,11 @@ val disableStrictModePatch = bytecodePatch(
 
         var patched = 0
         classDefForEach { classDef ->
-            val mutableClass = mutableClassDefBy(classDef)
-            for (method in mutableClass.methods) {
+            val mutableClass by lazy { mutableClassDefBy(classDef) }
+            for (method in classDef.methods) {
+                val mutableMethod by lazy {
+                    mutableClass.findMutableMethodOf(method)
+                }
                 val implementation = method.implementation ?: continue
                 val instructions = implementation.instructions.toList()
                 for ((index, instruction) in instructions.withIndex()) {
@@ -38,7 +42,7 @@ val disableStrictModePatch = bytecodePatch(
                         continue
                     }
 
-                    method.replaceInstruction(index, "nop")
+                    mutableMethod.replaceInstruction(index, "nop")
                     patched++
                 }
             }

--- a/patches/src/main/kotlin/patches/universal/misc/DisableVibrationPatch.kt
+++ b/patches/src/main/kotlin/patches/universal/misc/DisableVibrationPatch.kt
@@ -4,6 +4,7 @@ import app.morphe.patcher.extensions.InstructionExtensions.replaceInstruction
 import app.morphe.patcher.patch.bytecodePatch
 import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
 import com.android.tools.smali.dexlib2.iface.reference.MethodReference
+import patches.universal.ads.util.findMutableMethodOf
 import java.util.logging.Logger
 
 /** Framework classes whose void `vibrate(...)` methods are neutralised. */
@@ -26,8 +27,11 @@ val disableVibrationPatch = bytecodePatch(
 
         var patched = 0
         classDefForEach { classDef ->
-            val mutableClass = mutableClassDefBy(classDef)
-            for (method in mutableClass.methods) {
+            val mutableClass by lazy { mutableClassDefBy(classDef) }
+            for (method in classDef.methods) {
+                val mutableMethod by lazy {
+                    mutableClass.findMutableMethodOf(method)
+                }
                 // Snapshot of the instruction list; replacing one-for-one keeps indices valid.
                 val implementation = method.implementation ?: continue
                 val instructions = implementation.instructions.toList()
@@ -42,7 +46,7 @@ val disableVibrationPatch = bytecodePatch(
                         reference.name == "vibrate" &&
                         reference.returnType == "V"
                     ) {
-                        method.replaceInstruction(index, "nop")
+                        mutableMethod.replaceInstruction(index, "nop")
                         patched++
                     }
                 }

--- a/patches/src/main/kotlin/patches/universal/misc/DisableWebViewSafeBrowsingPatch.kt
+++ b/patches/src/main/kotlin/patches/universal/misc/DisableWebViewSafeBrowsingPatch.kt
@@ -4,13 +4,12 @@ import app.morphe.patcher.extensions.InstructionExtensions.replaceInstruction
 import app.morphe.patcher.patch.BytecodePatchContext
 import app.morphe.patcher.patch.bytecodePatch
 import com.android.tools.smali.dexlib2.Opcode
-import com.android.tools.smali.dexlib2.iface.instruction.FiveRegisterInstruction
-import com.android.tools.smali.dexlib2.iface.instruction.Instruction
 import com.android.tools.smali.dexlib2.iface.instruction.NarrowLiteralInstruction
 import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
 import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
-import com.android.tools.smali.dexlib2.iface.instruction.RegisterRangeInstruction
 import com.android.tools.smali.dexlib2.iface.reference.MethodReference
+import patches.universal.ads.util.findMutableMethodOf
+import patches.universal.ads.util.registersUsed
 import java.util.logging.Logger
 
 private fun BytecodePatchContext.forceBooleanSetter(
@@ -21,8 +20,11 @@ private fun BytecodePatchContext.forceBooleanSetter(
     val literal = if (value) "0x1" else "0x0"
     var patched = 0
     classDefForEach { classDef ->
-        val mutableClass = mutableClassDefBy(classDef)
-        for (method in mutableClass.methods) {
+        val mutableClass by lazy { mutableClassDefBy(classDef) }
+        for (method in classDef.methods) {
+            val mutableMethod by lazy {
+                mutableClass.findMutableMethodOf(method)
+            }
             val impl = method.implementation ?: continue
             val instructions = impl.instructions.toList()
             for ((index, insn) in instructions.withIndex()) {
@@ -33,12 +35,7 @@ private fun BytecodePatchContext.forceBooleanSetter(
                 if (ref.returnType != "V") continue
                 if (ref.parameterTypes != listOf("Z")) continue
 
-                val reg = when (insn) {
-                    is FiveRegisterInstruction -> insn.registerD
-                    is RegisterRangeInstruction -> insn.startRegister + insn.registerCount - 1
-                    else -> continue
-                }
-
+                val reg = insn.registersUsed[1]
                 for (j in index - 1 downTo 0) {
                     val prev = instructions[j]
                     if (prev.opcode == Opcode.NOP) continue
@@ -46,7 +43,7 @@ private fun BytecodePatchContext.forceBooleanSetter(
                         prev is OneRegisterInstruction &&
                         prev.registerA == reg
                     ) {
-                        method.replaceInstruction(j, "const/4 v$reg, $literal")
+                        mutableMethod.replaceInstruction(j, "const/4 v$reg, $literal")
                         patched++
                         break
                     }

--- a/patches/src/main/kotlin/patches/universal/misc/EnableUnrestrictedBackgroundWorkPatch.kt
+++ b/patches/src/main/kotlin/patches/universal/misc/EnableUnrestrictedBackgroundWorkPatch.kt
@@ -9,6 +9,7 @@ import com.android.tools.smali.dexlib2.builder.instruction.BuilderInstruction3rc
 import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
 import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
 import com.android.tools.smali.dexlib2.iface.reference.MethodReference
+import patches.universal.ads.util.findMutableMethodOf
 import java.util.logging.Logger
 
 @Suppress("unused")
@@ -32,8 +33,9 @@ val enableUnrestrictedBackgroundWorkPatch = bytecodePatch(
         }
         var patched = 0
         classDefForEach { classDef ->
-            val mutableClass = mutableClassDefBy(classDef)
-            for (method in mutableClass.methods) {
+            val mutableClass by lazy { mutableClassDefBy(classDef) }
+            for (method in classDef.methods) {
+                val mutableMethod by lazy { mutableClass.findMutableMethodOf(method) }
                 val impl = method.implementation ?: continue
                 val instructions = impl.instructions.toList()
                 for ((index, insn) in instructions.withIndex()) {
@@ -60,7 +62,7 @@ val enableUnrestrictedBackgroundWorkPatch = bytecodePatch(
                         val reg = (prev as? OneRegisterInstruction)?.registerA ?: continue
                         if (reg != argRegister) continue
                         val constInstr = if (reg <= 0xf) "const/4 v$reg, 0x0" else "const/16 v$reg, 0x0"
-                        method.replaceInstruction(j, constInstr)
+                        mutableMethod.replaceInstruction(j, constInstr)
                         patched++
                         break
                     }

--- a/patches/src/main/kotlin/patches/universal/misc/EnableWebViewAppCachePatch.kt
+++ b/patches/src/main/kotlin/patches/universal/misc/EnableWebViewAppCachePatch.kt
@@ -4,13 +4,12 @@ import app.morphe.patcher.extensions.InstructionExtensions.replaceInstruction
 import app.morphe.patcher.patch.BytecodePatchContext
 import app.morphe.patcher.patch.bytecodePatch
 import com.android.tools.smali.dexlib2.Opcode
-import com.android.tools.smali.dexlib2.iface.instruction.FiveRegisterInstruction
-import com.android.tools.smali.dexlib2.iface.instruction.Instruction
 import com.android.tools.smali.dexlib2.iface.instruction.NarrowLiteralInstruction
 import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
 import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
-import com.android.tools.smali.dexlib2.iface.instruction.RegisterRangeInstruction
 import com.android.tools.smali.dexlib2.iface.reference.MethodReference
+import patches.universal.ads.util.findMutableMethodOf
+import patches.universal.ads.util.registersUsed
 import java.util.logging.Logger
 
 private fun BytecodePatchContext.forceBooleanSetter(
@@ -21,8 +20,9 @@ private fun BytecodePatchContext.forceBooleanSetter(
     val literal = if (value) "0x1" else "0x0"
     var patched = 0
     classDefForEach { classDef ->
-        val mutableClass = mutableClassDefBy(classDef)
-        for (method in mutableClass.methods) {
+        val mutableClass by lazy { mutableClassDefBy(classDef) }
+        for (method in classDef.methods) {
+            val mutableMethod by lazy { mutableClass.findMutableMethodOf(method) }
             val impl = method.implementation ?: continue
             val instructions = impl.instructions.toList()
             for ((index, insn) in instructions.withIndex()) {
@@ -33,12 +33,7 @@ private fun BytecodePatchContext.forceBooleanSetter(
                 if (ref.returnType != "V") continue
                 if (ref.parameterTypes != listOf("Z")) continue
 
-                val reg = when (insn) {
-                    is FiveRegisterInstruction -> insn.registerD
-                    is RegisterRangeInstruction -> insn.startRegister + insn.registerCount - 1
-                    else -> continue
-                }
-
+                val reg = insn.registersUsed[1]
                 for (j in index - 1 downTo 0) {
                     val prev = instructions[j]
                     if (prev.opcode == Opcode.NOP) continue
@@ -46,7 +41,7 @@ private fun BytecodePatchContext.forceBooleanSetter(
                         prev is OneRegisterInstruction &&
                         prev.registerA == reg
                     ) {
-                        method.replaceInstruction(j, "const/4 v$reg, $literal")
+                        mutableMethod.replaceInstruction(j, "const/4 v$reg, $literal")
                         patched++
                         break
                     }

--- a/patches/src/main/kotlin/patches/universal/misc/EnableWebViewCachePatch.kt
+++ b/patches/src/main/kotlin/patches/universal/misc/EnableWebViewCachePatch.kt
@@ -4,13 +4,12 @@ import app.morphe.patcher.extensions.InstructionExtensions.replaceInstruction
 import app.morphe.patcher.patch.BytecodePatchContext
 import app.morphe.patcher.patch.bytecodePatch
 import com.android.tools.smali.dexlib2.Opcode
-import com.android.tools.smali.dexlib2.iface.instruction.FiveRegisterInstruction
-import com.android.tools.smali.dexlib2.iface.instruction.Instruction
 import com.android.tools.smali.dexlib2.iface.instruction.NarrowLiteralInstruction
 import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
 import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
-import com.android.tools.smali.dexlib2.iface.instruction.RegisterRangeInstruction
 import com.android.tools.smali.dexlib2.iface.reference.MethodReference
+import patches.universal.ads.util.findMutableMethodOf
+import patches.universal.ads.util.registersUsed
 import java.util.logging.Logger
 
 private fun BytecodePatchContext.forceIntSetter(
@@ -20,8 +19,9 @@ private fun BytecodePatchContext.forceIntSetter(
 ): Int {
     var patched = 0
     classDefForEach { classDef ->
-        val mutableClass = mutableClassDefBy(classDef)
-        for (method in mutableClass.methods) {
+        val mutableClass by lazy { mutableClassDefBy(classDef) }
+        for (method in classDef.methods) {
+            val mutableMethod by lazy { mutableClass.findMutableMethodOf(method) }
             val impl = method.implementation ?: continue
             val instructions = impl.instructions.toList()
             for ((index, insn) in instructions.withIndex()) {
@@ -32,12 +32,7 @@ private fun BytecodePatchContext.forceIntSetter(
                 if (ref.returnType != "V") continue
                 if (ref.parameterTypes != listOf("I")) continue
 
-                val reg = when (insn) {
-                    is FiveRegisterInstruction -> insn.registerD
-                    is RegisterRangeInstruction -> insn.startRegister + insn.registerCount - 1
-                    else -> continue
-                }
-
+                val reg = insn.registersUsed[1]
                 val constSmali = if (value in -8..7) {
                     "const/4 v$reg, 0x${value.toString(16)}"
                 } else {
@@ -51,7 +46,7 @@ private fun BytecodePatchContext.forceIntSetter(
                         prev is OneRegisterInstruction &&
                         prev.registerA == reg
                     ) {
-                        method.replaceInstruction(j, constSmali)
+                        mutableMethod.replaceInstruction(j, constSmali)
                         patched++
                         break
                     }

--- a/patches/src/main/kotlin/patches/universal/misc/EnableWebViewContentAccessPatch.kt
+++ b/patches/src/main/kotlin/patches/universal/misc/EnableWebViewContentAccessPatch.kt
@@ -4,13 +4,12 @@ import app.morphe.patcher.extensions.InstructionExtensions.replaceInstruction
 import app.morphe.patcher.patch.BytecodePatchContext
 import app.morphe.patcher.patch.bytecodePatch
 import com.android.tools.smali.dexlib2.Opcode
-import com.android.tools.smali.dexlib2.iface.instruction.FiveRegisterInstruction
-import com.android.tools.smali.dexlib2.iface.instruction.Instruction
 import com.android.tools.smali.dexlib2.iface.instruction.NarrowLiteralInstruction
 import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
 import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
-import com.android.tools.smali.dexlib2.iface.instruction.RegisterRangeInstruction
 import com.android.tools.smali.dexlib2.iface.reference.MethodReference
+import patches.universal.ads.util.findMutableMethodOf
+import patches.universal.ads.util.registersUsed
 import java.util.logging.Logger
 
 private fun BytecodePatchContext.forceBooleanSetter(
@@ -21,8 +20,9 @@ private fun BytecodePatchContext.forceBooleanSetter(
     val literal = if (value) "0x1" else "0x0"
     var patched = 0
     classDefForEach { classDef ->
-        val mutableClass = mutableClassDefBy(classDef)
-        for (method in mutableClass.methods) {
+        val mutableClass by lazy { mutableClassDefBy(classDef) }
+        for (method in classDef.methods) {
+            val mutableMethod by lazy { mutableClass.findMutableMethodOf(method) }
             val impl = method.implementation ?: continue
             val instructions = impl.instructions.toList()
             for ((index, insn) in instructions.withIndex()) {
@@ -33,12 +33,7 @@ private fun BytecodePatchContext.forceBooleanSetter(
                 if (ref.returnType != "V") continue
                 if (ref.parameterTypes != listOf("Z")) continue
 
-                val reg = when (insn) {
-                    is FiveRegisterInstruction -> insn.registerD
-                    is RegisterRangeInstruction -> insn.startRegister + insn.registerCount - 1
-                    else -> continue
-                }
-
+                val reg = insn.registersUsed[1]
                 for (j in index - 1 downTo 0) {
                     val prev = instructions[j]
                     if (prev.opcode == Opcode.NOP) continue
@@ -46,7 +41,7 @@ private fun BytecodePatchContext.forceBooleanSetter(
                         prev is OneRegisterInstruction &&
                         prev.registerA == reg
                     ) {
-                        method.replaceInstruction(j, "const/4 v$reg, $literal")
+                        mutableMethod.replaceInstruction(j, "const/4 v$reg, $literal")
                         patched++
                         break
                     }

--- a/patches/src/main/kotlin/patches/universal/misc/EnableWebViewDebuggingPatch.kt
+++ b/patches/src/main/kotlin/patches/universal/misc/EnableWebViewDebuggingPatch.kt
@@ -2,11 +2,11 @@ package patches.universal.misc
 
 import app.morphe.patcher.extensions.InstructionExtensions.addInstructions
 import app.morphe.patcher.patch.bytecodePatch
-import com.android.tools.smali.dexlib2.iface.instruction.FiveRegisterInstruction
-import com.android.tools.smali.dexlib2.iface.instruction.RegisterRangeInstruction
 import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
 import com.android.tools.smali.dexlib2.iface.reference.MethodReference
 import patches.universal.ads.util.cloneMutable
+import patches.universal.ads.util.findMutableMethodOf
+import patches.universal.ads.util.registersUsed
 import patches.universal.ui.findApplicationOnCreate
 import java.util.logging.Logger
 
@@ -28,8 +28,9 @@ val enableWebViewDebuggingPatch = bytecodePatch(
         //    overwriting the boolean argument register before the invoke.
         var forced = 0
         classDefForEach { classDef ->
-            val mutableClass = mutableClassDefBy(classDef)
-            for (method in mutableClass.methods) {
+            val mutableClass by lazy { mutableClassDefBy(classDef) }
+            for (method in classDef.methods) {
+                val mutableMethod by lazy { mutableClass.findMutableMethodOf(method) }
                 val implementation = method.implementation ?: continue
                 val instructions = implementation.instructions.toList()
 
@@ -47,18 +48,13 @@ val enableWebViewDebuggingPatch = bytecodePatch(
                         continue
                     }
 
-                    val argRegister = when (instruction) {
-                        is FiveRegisterInstruction -> instruction.registerC
-                        is RegisterRangeInstruction -> instruction.startRegister
-                        else -> null
-                    } ?: continue
-
+                    val argRegister = instruction.registersUsed[0]
                     insertions += index to "const/4 v$argRegister, 0x1"
                 }
 
                 if (insertions.isNotEmpty()) {
                     insertions.sortedByDescending { it.first }.forEach { (at, smali) ->
-                        method.addInstructions(at, smali)
+                        mutableMethod.addInstructions(at, smali)
                     }
                     forced += insertions.size
                 }

--- a/patches/src/main/kotlin/patches/universal/misc/EnableWebViewDomStoragePatch.kt
+++ b/patches/src/main/kotlin/patches/universal/misc/EnableWebViewDomStoragePatch.kt
@@ -4,13 +4,12 @@ import app.morphe.patcher.extensions.InstructionExtensions.replaceInstruction
 import app.morphe.patcher.patch.BytecodePatchContext
 import app.morphe.patcher.patch.bytecodePatch
 import com.android.tools.smali.dexlib2.Opcode
-import com.android.tools.smali.dexlib2.iface.instruction.FiveRegisterInstruction
-import com.android.tools.smali.dexlib2.iface.instruction.Instruction
 import com.android.tools.smali.dexlib2.iface.instruction.NarrowLiteralInstruction
 import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
 import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
-import com.android.tools.smali.dexlib2.iface.instruction.RegisterRangeInstruction
 import com.android.tools.smali.dexlib2.iface.reference.MethodReference
+import patches.universal.ads.util.findMutableMethodOf
+import patches.universal.ads.util.registersUsed
 import java.util.logging.Logger
 
 private fun BytecodePatchContext.forceBooleanSetter(
@@ -21,8 +20,9 @@ private fun BytecodePatchContext.forceBooleanSetter(
     val literal = if (value) "0x1" else "0x0"
     var patched = 0
     classDefForEach { classDef ->
-        val mutableClass = mutableClassDefBy(classDef)
-        for (method in mutableClass.methods) {
+        val mutableClass by lazy { mutableClassDefBy(classDef) }
+        for (method in classDef.methods) {
+            val mutableMethod by lazy { mutableClass.findMutableMethodOf(method) }
             val impl = method.implementation ?: continue
             val instructions = impl.instructions.toList()
             for ((index, insn) in instructions.withIndex()) {
@@ -33,12 +33,7 @@ private fun BytecodePatchContext.forceBooleanSetter(
                 if (ref.returnType != "V") continue
                 if (ref.parameterTypes != listOf("Z")) continue
 
-                val reg = when (insn) {
-                    is FiveRegisterInstruction -> insn.registerD
-                    is RegisterRangeInstruction -> insn.startRegister + insn.registerCount - 1
-                    else -> continue
-                }
-
+                val reg = insn.registersUsed[1]
                 for (j in index - 1 downTo 0) {
                     val prev = instructions[j]
                     if (prev.opcode == Opcode.NOP) continue
@@ -46,7 +41,7 @@ private fun BytecodePatchContext.forceBooleanSetter(
                         prev is OneRegisterInstruction &&
                         prev.registerA == reg
                     ) {
-                        method.replaceInstruction(j, "const/4 v$reg, $literal")
+                        mutableMethod.replaceInstruction(j, "const/4 v$reg, $literal")
                         patched++
                         break
                     }

--- a/patches/src/main/kotlin/patches/universal/misc/EnableWebViewGeolocationPatch.kt
+++ b/patches/src/main/kotlin/patches/universal/misc/EnableWebViewGeolocationPatch.kt
@@ -4,13 +4,12 @@ import app.morphe.patcher.extensions.InstructionExtensions.replaceInstruction
 import app.morphe.patcher.patch.BytecodePatchContext
 import app.morphe.patcher.patch.bytecodePatch
 import com.android.tools.smali.dexlib2.Opcode
-import com.android.tools.smali.dexlib2.iface.instruction.FiveRegisterInstruction
-import com.android.tools.smali.dexlib2.iface.instruction.Instruction
 import com.android.tools.smali.dexlib2.iface.instruction.NarrowLiteralInstruction
 import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
 import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
-import com.android.tools.smali.dexlib2.iface.instruction.RegisterRangeInstruction
 import com.android.tools.smali.dexlib2.iface.reference.MethodReference
+import patches.universal.ads.util.findMutableMethodOf
+import patches.universal.ads.util.registersUsed
 import java.util.logging.Logger
 
 private fun BytecodePatchContext.forceBooleanSetter(
@@ -21,8 +20,9 @@ private fun BytecodePatchContext.forceBooleanSetter(
     val literal = if (value) "0x1" else "0x0"
     var patched = 0
     classDefForEach { classDef ->
-        val mutableClass = mutableClassDefBy(classDef)
-        for (method in mutableClass.methods) {
+        val mutableClass by lazy { mutableClassDefBy(classDef) }
+        for (method in classDef.methods) {
+            val mutableMethod by lazy { mutableClass.findMutableMethodOf(method) }
             val impl = method.implementation ?: continue
             val instructions = impl.instructions.toList()
             for ((index, insn) in instructions.withIndex()) {
@@ -33,12 +33,7 @@ private fun BytecodePatchContext.forceBooleanSetter(
                 if (ref.returnType != "V") continue
                 if (ref.parameterTypes != listOf("Z")) continue
 
-                val reg = when (insn) {
-                    is FiveRegisterInstruction -> insn.registerD
-                    is RegisterRangeInstruction -> insn.startRegister + insn.registerCount - 1
-                    else -> continue
-                }
-
+                val reg = insn.registersUsed[1]
                 for (j in index - 1 downTo 0) {
                     val prev = instructions[j]
                     if (prev.opcode == Opcode.NOP) continue
@@ -46,7 +41,7 @@ private fun BytecodePatchContext.forceBooleanSetter(
                         prev is OneRegisterInstruction &&
                         prev.registerA == reg
                     ) {
-                        method.replaceInstruction(j, "const/4 v$reg, $literal")
+                        mutableMethod.replaceInstruction(j, "const/4 v$reg, $literal")
                         patched++
                         break
                     }

--- a/patches/src/main/kotlin/patches/universal/misc/EnableWebViewImageLoadingPatch.kt
+++ b/patches/src/main/kotlin/patches/universal/misc/EnableWebViewImageLoadingPatch.kt
@@ -4,13 +4,12 @@ import app.morphe.patcher.extensions.InstructionExtensions.replaceInstruction
 import app.morphe.patcher.patch.BytecodePatchContext
 import app.morphe.patcher.patch.bytecodePatch
 import com.android.tools.smali.dexlib2.Opcode
-import com.android.tools.smali.dexlib2.iface.instruction.FiveRegisterInstruction
-import com.android.tools.smali.dexlib2.iface.instruction.Instruction
 import com.android.tools.smali.dexlib2.iface.instruction.NarrowLiteralInstruction
 import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
 import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
-import com.android.tools.smali.dexlib2.iface.instruction.RegisterRangeInstruction
 import com.android.tools.smali.dexlib2.iface.reference.MethodReference
+import patches.universal.ads.util.findMutableMethodOf
+import patches.universal.ads.util.registersUsed
 import java.util.logging.Logger
 
 private fun BytecodePatchContext.forceBooleanSetter(
@@ -21,8 +20,9 @@ private fun BytecodePatchContext.forceBooleanSetter(
     val literal = if (value) "0x1" else "0x0"
     var patched = 0
     classDefForEach { classDef ->
-        val mutableClass = mutableClassDefBy(classDef)
-        for (method in mutableClass.methods) {
+        val mutableClass by lazy { mutableClassDefBy(classDef) }
+        for (method in classDef.methods) {
+            val mutableMethod by lazy { mutableClass.findMutableMethodOf(method) }
             val impl = method.implementation ?: continue
             val instructions = impl.instructions.toList()
             for ((index, insn) in instructions.withIndex()) {
@@ -33,12 +33,7 @@ private fun BytecodePatchContext.forceBooleanSetter(
                 if (ref.returnType != "V") continue
                 if (ref.parameterTypes != listOf("Z")) continue
 
-                val reg = when (insn) {
-                    is FiveRegisterInstruction -> insn.registerD
-                    is RegisterRangeInstruction -> insn.startRegister + insn.registerCount - 1
-                    else -> continue
-                }
-
+                val reg = insn.registersUsed[1]
                 for (j in index - 1 downTo 0) {
                     val prev = instructions[j]
                     if (prev.opcode == Opcode.NOP) continue
@@ -46,7 +41,7 @@ private fun BytecodePatchContext.forceBooleanSetter(
                         prev is OneRegisterInstruction &&
                         prev.registerA == reg
                     ) {
-                        method.replaceInstruction(j, "const/4 v$reg, $literal")
+                        mutableMethod.replaceInstruction(j, "const/4 v$reg, $literal")
                         patched++
                         break
                     }

--- a/patches/src/main/kotlin/patches/universal/misc/EnableWebViewInitialFocusPatch.kt
+++ b/patches/src/main/kotlin/patches/universal/misc/EnableWebViewInitialFocusPatch.kt
@@ -4,13 +4,12 @@ import app.morphe.patcher.extensions.InstructionExtensions.replaceInstruction
 import app.morphe.patcher.patch.BytecodePatchContext
 import app.morphe.patcher.patch.bytecodePatch
 import com.android.tools.smali.dexlib2.Opcode
-import com.android.tools.smali.dexlib2.iface.instruction.FiveRegisterInstruction
-import com.android.tools.smali.dexlib2.iface.instruction.Instruction
 import com.android.tools.smali.dexlib2.iface.instruction.NarrowLiteralInstruction
 import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
 import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
-import com.android.tools.smali.dexlib2.iface.instruction.RegisterRangeInstruction
 import com.android.tools.smali.dexlib2.iface.reference.MethodReference
+import patches.universal.ads.util.findMutableMethodOf
+import patches.universal.ads.util.registersUsed
 import java.util.logging.Logger
 
 private fun BytecodePatchContext.forceBooleanSetter(
@@ -21,8 +20,9 @@ private fun BytecodePatchContext.forceBooleanSetter(
     val literal = if (value) "0x1" else "0x0"
     var patched = 0
     classDefForEach { classDef ->
-        val mutableClass = mutableClassDefBy(classDef)
-        for (method in mutableClass.methods) {
+        val mutableClass by lazy { mutableClassDefBy(classDef) }
+        for (method in classDef.methods) {
+            val mutableMethod by lazy { mutableClass.findMutableMethodOf(method) }
             val impl = method.implementation ?: continue
             val instructions = impl.instructions.toList()
             for ((index, insn) in instructions.withIndex()) {
@@ -33,12 +33,7 @@ private fun BytecodePatchContext.forceBooleanSetter(
                 if (ref.returnType != "V") continue
                 if (ref.parameterTypes != listOf("Z")) continue
 
-                val reg = when (insn) {
-                    is FiveRegisterInstruction -> insn.registerD
-                    is RegisterRangeInstruction -> insn.startRegister + insn.registerCount - 1
-                    else -> continue
-                }
-
+                val reg = insn.registersUsed[1]
                 for (j in index - 1 downTo 0) {
                     val prev = instructions[j]
                     if (prev.opcode == Opcode.NOP) continue
@@ -46,7 +41,7 @@ private fun BytecodePatchContext.forceBooleanSetter(
                         prev is OneRegisterInstruction &&
                         prev.registerA == reg
                     ) {
-                        method.replaceInstruction(j, "const/4 v$reg, $literal")
+                        mutableMethod.replaceInstruction(j, "const/4 v$reg, $literal")
                         patched++
                         break
                     }

--- a/patches/src/main/kotlin/patches/universal/misc/EnableWebViewJavaScriptPatch.kt
+++ b/patches/src/main/kotlin/patches/universal/misc/EnableWebViewJavaScriptPatch.kt
@@ -4,13 +4,12 @@ import app.morphe.patcher.extensions.InstructionExtensions.replaceInstruction
 import app.morphe.patcher.patch.BytecodePatchContext
 import app.morphe.patcher.patch.bytecodePatch
 import com.android.tools.smali.dexlib2.Opcode
-import com.android.tools.smali.dexlib2.iface.instruction.FiveRegisterInstruction
-import com.android.tools.smali.dexlib2.iface.instruction.Instruction
 import com.android.tools.smali.dexlib2.iface.instruction.NarrowLiteralInstruction
 import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
 import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
-import com.android.tools.smali.dexlib2.iface.instruction.RegisterRangeInstruction
 import com.android.tools.smali.dexlib2.iface.reference.MethodReference
+import patches.universal.ads.util.findMutableMethodOf
+import patches.universal.ads.util.registersUsed
 import java.util.logging.Logger
 
 private fun BytecodePatchContext.forceBooleanSetter(
@@ -21,8 +20,9 @@ private fun BytecodePatchContext.forceBooleanSetter(
     val literal = if (value) "0x1" else "0x0"
     var patched = 0
     classDefForEach { classDef ->
-        val mutableClass = mutableClassDefBy(classDef)
-        for (method in mutableClass.methods) {
+        val mutableClass by lazy { mutableClassDefBy(classDef) }
+        for (method in classDef.methods) {
+            val mutableMethod by lazy { mutableClass.findMutableMethodOf(method) }
             val impl = method.implementation ?: continue
             val instructions = impl.instructions.toList()
             for ((index, insn) in instructions.withIndex()) {
@@ -33,12 +33,7 @@ private fun BytecodePatchContext.forceBooleanSetter(
                 if (ref.returnType != "V") continue
                 if (ref.parameterTypes != listOf("Z")) continue
 
-                val reg = when (insn) {
-                    is FiveRegisterInstruction -> insn.registerD
-                    is RegisterRangeInstruction -> insn.startRegister + insn.registerCount - 1
-                    else -> continue
-                }
-
+                val reg = insn.registersUsed[1]
                 for (j in index - 1 downTo 0) {
                     val prev = instructions[j]
                     if (prev.opcode == Opcode.NOP) continue
@@ -46,7 +41,7 @@ private fun BytecodePatchContext.forceBooleanSetter(
                         prev is OneRegisterInstruction &&
                         prev.registerA == reg
                     ) {
-                        method.replaceInstruction(j, "const/4 v$reg, $literal")
+                        mutableMethod.replaceInstruction(j, "const/4 v$reg, $literal")
                         patched++
                         break
                     }

--- a/patches/src/main/kotlin/patches/universal/misc/EnableWebViewOffscreenPreRasterPatch.kt
+++ b/patches/src/main/kotlin/patches/universal/misc/EnableWebViewOffscreenPreRasterPatch.kt
@@ -4,13 +4,12 @@ import app.morphe.patcher.extensions.InstructionExtensions.replaceInstruction
 import app.morphe.patcher.patch.BytecodePatchContext
 import app.morphe.patcher.patch.bytecodePatch
 import com.android.tools.smali.dexlib2.Opcode
-import com.android.tools.smali.dexlib2.iface.instruction.FiveRegisterInstruction
-import com.android.tools.smali.dexlib2.iface.instruction.Instruction
 import com.android.tools.smali.dexlib2.iface.instruction.NarrowLiteralInstruction
 import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
 import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
-import com.android.tools.smali.dexlib2.iface.instruction.RegisterRangeInstruction
 import com.android.tools.smali.dexlib2.iface.reference.MethodReference
+import patches.universal.ads.util.findMutableMethodOf
+import patches.universal.ads.util.registersUsed
 import java.util.logging.Logger
 
 private fun BytecodePatchContext.forceBooleanSetter(
@@ -21,8 +20,9 @@ private fun BytecodePatchContext.forceBooleanSetter(
     val literal = if (value) "0x1" else "0x0"
     var patched = 0
     classDefForEach { classDef ->
-        val mutableClass = mutableClassDefBy(classDef)
-        for (method in mutableClass.methods) {
+        val mutableClass by lazy { mutableClassDefBy(classDef) }
+        for (method in classDef.methods) {
+            val mutableMethod by lazy { mutableClass.findMutableMethodOf(method) }
             val impl = method.implementation ?: continue
             val instructions = impl.instructions.toList()
             for ((index, insn) in instructions.withIndex()) {
@@ -33,12 +33,7 @@ private fun BytecodePatchContext.forceBooleanSetter(
                 if (ref.returnType != "V") continue
                 if (ref.parameterTypes != listOf("Z")) continue
 
-                val reg = when (insn) {
-                    is FiveRegisterInstruction -> insn.registerD
-                    is RegisterRangeInstruction -> insn.startRegister + insn.registerCount - 1
-                    else -> continue
-                }
-
+                val reg = insn.registersUsed[1]
                 for (j in index - 1 downTo 0) {
                     val prev = instructions[j]
                     if (prev.opcode == Opcode.NOP) continue
@@ -46,7 +41,7 @@ private fun BytecodePatchContext.forceBooleanSetter(
                         prev is OneRegisterInstruction &&
                         prev.registerA == reg
                     ) {
-                        method.replaceInstruction(j, "const/4 v$reg, $literal")
+                        mutableMethod.replaceInstruction(j, "const/4 v$reg, $literal")
                         patched++
                         break
                     }

--- a/patches/src/main/kotlin/patches/universal/misc/EnableWebViewPopupsPatch.kt
+++ b/patches/src/main/kotlin/patches/universal/misc/EnableWebViewPopupsPatch.kt
@@ -4,13 +4,12 @@ import app.morphe.patcher.extensions.InstructionExtensions.replaceInstruction
 import app.morphe.patcher.patch.BytecodePatchContext
 import app.morphe.patcher.patch.bytecodePatch
 import com.android.tools.smali.dexlib2.Opcode
-import com.android.tools.smali.dexlib2.iface.instruction.FiveRegisterInstruction
-import com.android.tools.smali.dexlib2.iface.instruction.Instruction
 import com.android.tools.smali.dexlib2.iface.instruction.NarrowLiteralInstruction
 import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
 import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
-import com.android.tools.smali.dexlib2.iface.instruction.RegisterRangeInstruction
 import com.android.tools.smali.dexlib2.iface.reference.MethodReference
+import patches.universal.ads.util.findMutableMethodOf
+import patches.universal.ads.util.registersUsed
 import java.util.logging.Logger
 
 private fun BytecodePatchContext.forceBooleanSetter(
@@ -21,8 +20,9 @@ private fun BytecodePatchContext.forceBooleanSetter(
     val literal = if (value) "0x1" else "0x0"
     var patched = 0
     classDefForEach { classDef ->
-        val mutableClass = mutableClassDefBy(classDef)
-        for (method in mutableClass.methods) {
+        val mutableClass by lazy { mutableClassDefBy(classDef) }
+        for (method in classDef.methods) {
+            val mutableMethod by lazy { mutableClass.findMutableMethodOf(method) }
             val impl = method.implementation ?: continue
             val instructions = impl.instructions.toList()
             for ((index, insn) in instructions.withIndex()) {
@@ -33,12 +33,7 @@ private fun BytecodePatchContext.forceBooleanSetter(
                 if (ref.returnType != "V") continue
                 if (ref.parameterTypes != listOf("Z")) continue
 
-                val reg = when (insn) {
-                    is FiveRegisterInstruction -> insn.registerD
-                    is RegisterRangeInstruction -> insn.startRegister + insn.registerCount - 1
-                    else -> continue
-                }
-
+                val reg = insn.registersUsed[1]
                 for (j in index - 1 downTo 0) {
                     val prev = instructions[j]
                     if (prev.opcode == Opcode.NOP) continue
@@ -46,7 +41,7 @@ private fun BytecodePatchContext.forceBooleanSetter(
                         prev is OneRegisterInstruction &&
                         prev.registerA == reg
                     ) {
-                        method.replaceInstruction(j, "const/4 v$reg, $literal")
+                        mutableMethod.replaceInstruction(j, "const/4 v$reg, $literal")
                         patched++
                         break
                     }

--- a/patches/src/main/kotlin/patches/universal/misc/EnableWebViewSaveFormDataPatch.kt
+++ b/patches/src/main/kotlin/patches/universal/misc/EnableWebViewSaveFormDataPatch.kt
@@ -4,13 +4,12 @@ import app.morphe.patcher.extensions.InstructionExtensions.replaceInstruction
 import app.morphe.patcher.patch.BytecodePatchContext
 import app.morphe.patcher.patch.bytecodePatch
 import com.android.tools.smali.dexlib2.Opcode
-import com.android.tools.smali.dexlib2.iface.instruction.FiveRegisterInstruction
-import com.android.tools.smali.dexlib2.iface.instruction.Instruction
 import com.android.tools.smali.dexlib2.iface.instruction.NarrowLiteralInstruction
 import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
 import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
-import com.android.tools.smali.dexlib2.iface.instruction.RegisterRangeInstruction
 import com.android.tools.smali.dexlib2.iface.reference.MethodReference
+import patches.universal.ads.util.findMutableMethodOf
+import patches.universal.ads.util.registersUsed
 import java.util.logging.Logger
 
 private fun BytecodePatchContext.forceBooleanSetter(
@@ -21,8 +20,9 @@ private fun BytecodePatchContext.forceBooleanSetter(
     val literal = if (value) "0x1" else "0x0"
     var patched = 0
     classDefForEach { classDef ->
-        val mutableClass = mutableClassDefBy(classDef)
-        for (method in mutableClass.methods) {
+        val mutableClass by lazy { mutableClassDefBy(classDef) }
+        for (method in classDef.methods) {
+            val mutableMethod by lazy { mutableClass.findMutableMethodOf(method) }
             val impl = method.implementation ?: continue
             val instructions = impl.instructions.toList()
             for ((index, insn) in instructions.withIndex()) {
@@ -33,12 +33,7 @@ private fun BytecodePatchContext.forceBooleanSetter(
                 if (ref.returnType != "V") continue
                 if (ref.parameterTypes != listOf("Z")) continue
 
-                val reg = when (insn) {
-                    is FiveRegisterInstruction -> insn.registerD
-                    is RegisterRangeInstruction -> insn.startRegister + insn.registerCount - 1
-                    else -> continue
-                }
-
+                val reg = insn.registersUsed[1]
                 for (j in index - 1 downTo 0) {
                     val prev = instructions[j]
                     if (prev.opcode == Opcode.NOP) continue
@@ -46,7 +41,7 @@ private fun BytecodePatchContext.forceBooleanSetter(
                         prev is OneRegisterInstruction &&
                         prev.registerA == reg
                     ) {
-                        method.replaceInstruction(j, "const/4 v$reg, $literal")
+                        mutableMethod.replaceInstruction(j, "const/4 v$reg, $literal")
                         patched++
                         break
                     }

--- a/patches/src/main/kotlin/patches/universal/misc/EnableWebViewSavePasswordPatch.kt
+++ b/patches/src/main/kotlin/patches/universal/misc/EnableWebViewSavePasswordPatch.kt
@@ -4,13 +4,12 @@ import app.morphe.patcher.extensions.InstructionExtensions.replaceInstruction
 import app.morphe.patcher.patch.BytecodePatchContext
 import app.morphe.patcher.patch.bytecodePatch
 import com.android.tools.smali.dexlib2.Opcode
-import com.android.tools.smali.dexlib2.iface.instruction.FiveRegisterInstruction
-import com.android.tools.smali.dexlib2.iface.instruction.Instruction
 import com.android.tools.smali.dexlib2.iface.instruction.NarrowLiteralInstruction
 import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
 import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
-import com.android.tools.smali.dexlib2.iface.instruction.RegisterRangeInstruction
 import com.android.tools.smali.dexlib2.iface.reference.MethodReference
+import patches.universal.ads.util.findMutableMethodOf
+import patches.universal.ads.util.registersUsed
 import java.util.logging.Logger
 
 private fun BytecodePatchContext.forceBooleanSetter(
@@ -21,8 +20,9 @@ private fun BytecodePatchContext.forceBooleanSetter(
     val literal = if (value) "0x1" else "0x0"
     var patched = 0
     classDefForEach { classDef ->
-        val mutableClass = mutableClassDefBy(classDef)
-        for (method in mutableClass.methods) {
+        val mutableClass by lazy { mutableClassDefBy(classDef) }
+        for (method in classDef.methods) {
+            val mutableMethod by lazy { mutableClass.findMutableMethodOf(method) }
             val impl = method.implementation ?: continue
             val instructions = impl.instructions.toList()
             for ((index, insn) in instructions.withIndex()) {
@@ -33,12 +33,7 @@ private fun BytecodePatchContext.forceBooleanSetter(
                 if (ref.returnType != "V") continue
                 if (ref.parameterTypes != listOf("Z")) continue
 
-                val reg = when (insn) {
-                    is FiveRegisterInstruction -> insn.registerD
-                    is RegisterRangeInstruction -> insn.startRegister + insn.registerCount - 1
-                    else -> continue
-                }
-
+                val reg = insn.registersUsed[1]
                 for (j in index - 1 downTo 0) {
                     val prev = instructions[j]
                     if (prev.opcode == Opcode.NOP) continue
@@ -46,7 +41,7 @@ private fun BytecodePatchContext.forceBooleanSetter(
                         prev is OneRegisterInstruction &&
                         prev.registerA == reg
                     ) {
-                        method.replaceInstruction(j, "const/4 v$reg, $literal")
+                        mutableMethod.replaceInstruction(j, "const/4 v$reg, $literal")
                         patched++
                         break
                     }

--- a/patches/src/main/kotlin/patches/universal/misc/EnableWebViewWideViewportPatch.kt
+++ b/patches/src/main/kotlin/patches/universal/misc/EnableWebViewWideViewportPatch.kt
@@ -4,13 +4,12 @@ import app.morphe.patcher.extensions.InstructionExtensions.replaceInstruction
 import app.morphe.patcher.patch.BytecodePatchContext
 import app.morphe.patcher.patch.bytecodePatch
 import com.android.tools.smali.dexlib2.Opcode
-import com.android.tools.smali.dexlib2.iface.instruction.FiveRegisterInstruction
-import com.android.tools.smali.dexlib2.iface.instruction.Instruction
 import com.android.tools.smali.dexlib2.iface.instruction.NarrowLiteralInstruction
 import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
 import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
-import com.android.tools.smali.dexlib2.iface.instruction.RegisterRangeInstruction
 import com.android.tools.smali.dexlib2.iface.reference.MethodReference
+import patches.universal.ads.util.findMutableMethodOf
+import patches.universal.ads.util.registersUsed
 import java.util.logging.Logger
 
 private fun BytecodePatchContext.forceBooleanSetter(
@@ -21,8 +20,9 @@ private fun BytecodePatchContext.forceBooleanSetter(
     val literal = if (value) "0x1" else "0x0"
     var patched = 0
     classDefForEach { classDef ->
-        val mutableClass = mutableClassDefBy(classDef)
-        for (method in mutableClass.methods) {
+        val mutableClass by lazy { mutableClassDefBy(classDef) }
+        for (method in classDef.methods) {
+            val mutableMethod by lazy { mutableClass.findMutableMethodOf(method) }
             val impl = method.implementation ?: continue
             val instructions = impl.instructions.toList()
             for ((index, insn) in instructions.withIndex()) {
@@ -33,12 +33,7 @@ private fun BytecodePatchContext.forceBooleanSetter(
                 if (ref.returnType != "V") continue
                 if (ref.parameterTypes != listOf("Z")) continue
 
-                val reg = when (insn) {
-                    is FiveRegisterInstruction -> insn.registerD
-                    is RegisterRangeInstruction -> insn.startRegister + insn.registerCount - 1
-                    else -> continue
-                }
-
+                val reg = insn.registersUsed[1]
                 for (j in index - 1 downTo 0) {
                     val prev = instructions[j]
                     if (prev.opcode == Opcode.NOP) continue
@@ -46,7 +41,7 @@ private fun BytecodePatchContext.forceBooleanSetter(
                         prev is OneRegisterInstruction &&
                         prev.registerA == reg
                     ) {
-                        method.replaceInstruction(j, "const/4 v$reg, $literal")
+                        mutableMethod.replaceInstruction(j, "const/4 v$reg, $literal")
                         patched++
                         break
                     }

--- a/patches/src/main/kotlin/patches/universal/misc/EnableWebViewZoomPatch.kt
+++ b/patches/src/main/kotlin/patches/universal/misc/EnableWebViewZoomPatch.kt
@@ -4,13 +4,12 @@ import app.morphe.patcher.extensions.InstructionExtensions.replaceInstruction
 import app.morphe.patcher.patch.BytecodePatchContext
 import app.morphe.patcher.patch.bytecodePatch
 import com.android.tools.smali.dexlib2.Opcode
-import com.android.tools.smali.dexlib2.iface.instruction.FiveRegisterInstruction
-import com.android.tools.smali.dexlib2.iface.instruction.Instruction
 import com.android.tools.smali.dexlib2.iface.instruction.NarrowLiteralInstruction
 import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
 import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
-import com.android.tools.smali.dexlib2.iface.instruction.RegisterRangeInstruction
 import com.android.tools.smali.dexlib2.iface.reference.MethodReference
+import patches.universal.ads.util.findMutableMethodOf
+import patches.universal.ads.util.registersUsed
 import java.util.logging.Logger
 
 private fun BytecodePatchContext.forceBooleanSetter(
@@ -21,8 +20,9 @@ private fun BytecodePatchContext.forceBooleanSetter(
     val literal = if (value) "0x1" else "0x0"
     var patched = 0
     classDefForEach { classDef ->
-        val mutableClass = mutableClassDefBy(classDef)
-        for (method in mutableClass.methods) {
+        val mutableClass by lazy { mutableClassDefBy(classDef) }
+        for (method in classDef.methods) {
+            val mutableMethod by lazy { mutableClass.findMutableMethodOf(method) }
             val impl = method.implementation ?: continue
             val instructions = impl.instructions.toList()
             for ((index, insn) in instructions.withIndex()) {
@@ -33,12 +33,7 @@ private fun BytecodePatchContext.forceBooleanSetter(
                 if (ref.returnType != "V") continue
                 if (ref.parameterTypes != listOf("Z")) continue
 
-                val reg = when (insn) {
-                    is FiveRegisterInstruction -> insn.registerD
-                    is RegisterRangeInstruction -> insn.startRegister + insn.registerCount - 1
-                    else -> continue
-                }
-
+                val reg = insn.registersUsed[1]
                 for (j in index - 1 downTo 0) {
                     val prev = instructions[j]
                     if (prev.opcode == Opcode.NOP) continue
@@ -46,7 +41,7 @@ private fun BytecodePatchContext.forceBooleanSetter(
                         prev is OneRegisterInstruction &&
                         prev.registerA == reg
                     ) {
-                        method.replaceInstruction(j, "const/4 v$reg, $literal")
+                        mutableMethod.replaceInstruction(j, "const/4 v$reg, $literal")
                         patched++
                         break
                     }

--- a/patches/src/main/kotlin/patches/universal/misc/EnableWebViewZoomSupportPatch.kt
+++ b/patches/src/main/kotlin/patches/universal/misc/EnableWebViewZoomSupportPatch.kt
@@ -4,13 +4,12 @@ import app.morphe.patcher.extensions.InstructionExtensions.replaceInstruction
 import app.morphe.patcher.patch.BytecodePatchContext
 import app.morphe.patcher.patch.bytecodePatch
 import com.android.tools.smali.dexlib2.Opcode
-import com.android.tools.smali.dexlib2.iface.instruction.FiveRegisterInstruction
-import com.android.tools.smali.dexlib2.iface.instruction.Instruction
 import com.android.tools.smali.dexlib2.iface.instruction.NarrowLiteralInstruction
 import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
 import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
-import com.android.tools.smali.dexlib2.iface.instruction.RegisterRangeInstruction
 import com.android.tools.smali.dexlib2.iface.reference.MethodReference
+import patches.universal.ads.util.findMutableMethodOf
+import patches.universal.ads.util.registersUsed
 import java.util.logging.Logger
 
 private fun BytecodePatchContext.forceBooleanSetter(
@@ -21,8 +20,9 @@ private fun BytecodePatchContext.forceBooleanSetter(
     val literal = if (value) "0x1" else "0x0"
     var patched = 0
     classDefForEach { classDef ->
-        val mutableClass = mutableClassDefBy(classDef)
-        for (method in mutableClass.methods) {
+        val mutableClass by lazy { mutableClassDefBy(classDef) }
+        for (method in classDef.methods) {
+            val mutableMethod by lazy { mutableClass.findMutableMethodOf(method) }
             val impl = method.implementation ?: continue
             val instructions = impl.instructions.toList()
             for ((index, insn) in instructions.withIndex()) {
@@ -33,12 +33,7 @@ private fun BytecodePatchContext.forceBooleanSetter(
                 if (ref.returnType != "V") continue
                 if (ref.parameterTypes != listOf("Z")) continue
 
-                val reg = when (insn) {
-                    is FiveRegisterInstruction -> insn.registerD
-                    is RegisterRangeInstruction -> insn.startRegister + insn.registerCount - 1
-                    else -> continue
-                }
-
+                val reg = insn.registersUsed[1]
                 for (j in index - 1 downTo 0) {
                     val prev = instructions[j]
                     if (prev.opcode == Opcode.NOP) continue
@@ -46,7 +41,7 @@ private fun BytecodePatchContext.forceBooleanSetter(
                         prev is OneRegisterInstruction &&
                         prev.registerA == reg
                     ) {
-                        method.replaceInstruction(j, "const/4 v$reg, $literal")
+                        mutableMethod.replaceInstruction(j, "const/4 v$reg, $literal")
                         patched++
                         break
                     }

--- a/patches/src/main/kotlin/patches/universal/misc/FakeAdbEnabledPatch.kt
+++ b/patches/src/main/kotlin/patches/universal/misc/FakeAdbEnabledPatch.kt
@@ -1,8 +1,8 @@
 package patches.universal.misc
 
 import app.morphe.patcher.extensions.InstructionExtensions.replaceInstruction
-import app.morphe.patcher.patch.bytecodePatch
 import app.morphe.patcher.patch.booleanOption
+import app.morphe.patcher.patch.bytecodePatch
 import com.android.tools.smali.dexlib2.Opcode
 import com.android.tools.smali.dexlib2.builder.instruction.BuilderInstruction35c
 import com.android.tools.smali.dexlib2.builder.instruction.BuilderInstruction3rc
@@ -11,6 +11,7 @@ import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
 import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
 import com.android.tools.smali.dexlib2.iface.reference.MethodReference
 import com.android.tools.smali.dexlib2.iface.reference.StringReference
+import patches.universal.ads.util.findMutableMethodOf
 import java.util.logging.Logger
 
 @Suppress("unused")
@@ -32,8 +33,9 @@ val fakeAdbEnabledPatch = bytecodePatch(
 
         var patched = 0
         classDefForEach { classDef ->
-            val mutableClass = mutableClassDefBy(classDef)
-            for (method in mutableClass.methods) {
+            val mutableClass by lazy { mutableClassDefBy(classDef) }
+            for (method in classDef.methods) {
+                val mutableMethod by lazy { mutableClass.findMutableMethodOf(method) }
                 val implementation = method.implementation ?: continue
                 val instructions: List<Instruction> = implementation.instructions.toList()
                 for ((index, instruction) in instructions.withIndex()) {
@@ -71,8 +73,8 @@ val fakeAdbEnabledPatch = bytecodePatch(
                     val next = instructions.getOrNull(index + 1)
                     if (next != null && next.opcode == Opcode.MOVE_RESULT) {
                         val resultRegister = (next as OneRegisterInstruction).registerA
-                        method.replaceInstruction(index, "const/4 v$resultRegister, $target")
-                        method.replaceInstruction(index + 1, "nop")
+                        mutableMethod.replaceInstruction(index, "const/4 v$resultRegister, $target")
+                        mutableMethod.replaceInstruction(index + 1, "nop")
                         patched++
                     }
                 }

--- a/patches/src/main/kotlin/patches/universal/misc/FakeAnimationScalesPatch.kt
+++ b/patches/src/main/kotlin/patches/universal/misc/FakeAnimationScalesPatch.kt
@@ -11,6 +11,7 @@ import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
 import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
 import com.android.tools.smali.dexlib2.iface.reference.MethodReference
 import com.android.tools.smali.dexlib2.iface.reference.StringReference
+import patches.universal.ads.util.findMutableMethodOf
 import java.util.logging.Logger
 
 @Suppress("unused")
@@ -37,8 +38,9 @@ val fakeAnimationScalesPatch = bytecodePatch(
         val keys = setOf("window_animation_scale", "transition_animation_scale", "animator_duration_scale")
         var patched = 0
         classDefForEach { classDef ->
-            val mutableClass = mutableClassDefBy(classDef)
-            for (method in mutableClass.methods) {
+            val mutableClass by lazy { mutableClassDefBy(classDef) }
+            for (method in classDef.methods) {
+                val mutableMethod by lazy { mutableClass.findMutableMethodOf(method) }
                 val impl = method.implementation ?: continue
                 val instructions: List<Instruction> = impl.instructions.toList()
                 for ((index, insn) in instructions.withIndex()) {
@@ -74,8 +76,8 @@ val fakeAnimationScalesPatch = bytecodePatch(
                             "0.5" -> "0x3f000000"
                             else -> "0x0"
                         }
-                        method.replaceInstruction(index, "const/high16 v$resultRegister, $hex")
-                        method.replaceInstruction(index + 1, "nop")
+                        mutableMethod.replaceInstruction(index, "const/high16 v$resultRegister, $hex")
+                        mutableMethod.replaceInstruction(index + 1, "nop")
                         patched++
                     }
                 }

--- a/patches/src/main/kotlin/patches/universal/misc/FakeAutoRotatePatch.kt
+++ b/patches/src/main/kotlin/patches/universal/misc/FakeAutoRotatePatch.kt
@@ -1,8 +1,8 @@
 package patches.universal.misc
 
 import app.morphe.patcher.extensions.InstructionExtensions.replaceInstruction
-import app.morphe.patcher.patch.bytecodePatch
 import app.morphe.patcher.patch.booleanOption
+import app.morphe.patcher.patch.bytecodePatch
 import com.android.tools.smali.dexlib2.Opcode
 import com.android.tools.smali.dexlib2.builder.instruction.BuilderInstruction35c
 import com.android.tools.smali.dexlib2.builder.instruction.BuilderInstruction3rc
@@ -11,6 +11,7 @@ import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
 import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
 import com.android.tools.smali.dexlib2.iface.reference.MethodReference
 import com.android.tools.smali.dexlib2.iface.reference.StringReference
+import patches.universal.ads.util.findMutableMethodOf
 import java.util.logging.Logger
 
 @Suppress("unused")
@@ -32,8 +33,9 @@ val fakeAutoRotatePatch = bytecodePatch(
 
         var patched = 0
         classDefForEach { classDef ->
-            val mutableClass = mutableClassDefBy(classDef)
-            for (method in mutableClass.methods) {
+            val mutableClass by lazy { mutableClassDefBy(classDef) }
+            for (method in classDef.methods) {
+                val mutableMethod by lazy { mutableClass.findMutableMethodOf(method) }
                 val implementation = method.implementation ?: continue
                 val instructions: List<Instruction> = implementation.instructions.toList()
                 for ((index, instruction) in instructions.withIndex()) {
@@ -71,8 +73,8 @@ val fakeAutoRotatePatch = bytecodePatch(
                     val next = instructions.getOrNull(index + 1)
                     if (next != null && next.opcode == Opcode.MOVE_RESULT) {
                         val resultRegister = (next as OneRegisterInstruction).registerA
-                        method.replaceInstruction(index, "const/4 v$resultRegister, $target")
-                        method.replaceInstruction(index + 1, "nop")
+                        mutableMethod.replaceInstruction(index, "const/4 v$resultRegister, $target")
+                        mutableMethod.replaceInstruction(index + 1, "nop")
                         patched++
                     }
                 }

--- a/patches/src/main/kotlin/patches/universal/misc/FakeAutoTimePatch.kt
+++ b/patches/src/main/kotlin/patches/universal/misc/FakeAutoTimePatch.kt
@@ -11,6 +11,7 @@ import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
 import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
 import com.android.tools.smali.dexlib2.iface.reference.MethodReference
 import com.android.tools.smali.dexlib2.iface.reference.StringReference
+import patches.universal.ads.util.findMutableMethodOf
 import java.util.logging.Logger
 
 @Suppress("unused")
@@ -32,8 +33,9 @@ val fakeAutoTimePatch = bytecodePatch(
 
         var patched = 0
         classDefForEach { classDef ->
-            val mutableClass = mutableClassDefBy(classDef)
-            for (method in mutableClass.methods) {
+            val mutableClass by lazy { mutableClassDefBy(classDef) }
+            for (method in classDef.methods) {
+                val mutableMethod by lazy { mutableClass.findMutableMethodOf(method) }
                 val implementation = method.implementation ?: continue
                 val instructions: List<Instruction> = implementation.instructions.toList()
                 for ((index, instruction) in instructions.withIndex()) {
@@ -71,8 +73,8 @@ val fakeAutoTimePatch = bytecodePatch(
                     val next = instructions.getOrNull(index + 1)
                     if (next != null && next.opcode == Opcode.MOVE_RESULT) {
                         val resultRegister = (next as OneRegisterInstruction).registerA
-                        method.replaceInstruction(index, "const/4 v$resultRegister, $target")
-                        method.replaceInstruction(index + 1, "nop")
+                        mutableMethod.replaceInstruction(index, "const/4 v$resultRegister, $target")
+                        mutableMethod.replaceInstruction(index + 1, "nop")
                         patched++
                     }
                 }

--- a/patches/src/main/kotlin/patches/universal/misc/FakeAutoTimeZonePatch.kt
+++ b/patches/src/main/kotlin/patches/universal/misc/FakeAutoTimeZonePatch.kt
@@ -11,6 +11,7 @@ import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
 import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
 import com.android.tools.smali.dexlib2.iface.reference.MethodReference
 import com.android.tools.smali.dexlib2.iface.reference.StringReference
+import patches.universal.ads.util.findMutableMethodOf
 import java.util.logging.Logger
 
 @Suppress("unused")
@@ -32,8 +33,9 @@ val fakeAutoTimeZonePatch = bytecodePatch(
 
         var patched = 0
         classDefForEach { classDef ->
-            val mutableClass = mutableClassDefBy(classDef)
-            for (method in mutableClass.methods) {
+            val mutableClass by lazy { mutableClassDefBy(classDef) }
+            for (method in classDef.methods) {
+                val mutableMethod by lazy { mutableClass.findMutableMethodOf(method) }
                 val implementation = method.implementation ?: continue
                 val instructions: List<Instruction> = implementation.instructions.toList()
                 for ((index, instruction) in instructions.withIndex()) {
@@ -71,8 +73,8 @@ val fakeAutoTimeZonePatch = bytecodePatch(
                     val next = instructions.getOrNull(index + 1)
                     if (next != null && next.opcode == Opcode.MOVE_RESULT) {
                         val resultRegister = (next as OneRegisterInstruction).registerA
-                        method.replaceInstruction(index, "const/4 v$resultRegister, $target")
-                        method.replaceInstruction(index + 1, "nop")
+                        mutableMethod.replaceInstruction(index, "const/4 v$resultRegister, $target")
+                        mutableMethod.replaceInstruction(index + 1, "nop")
                         patched++
                     }
                 }

--- a/patches/src/main/kotlin/patches/universal/misc/FakeBatteryWhitelistPatch.kt
+++ b/patches/src/main/kotlin/patches/universal/misc/FakeBatteryWhitelistPatch.kt
@@ -7,6 +7,7 @@ import com.android.tools.smali.dexlib2.Opcode
 import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
 import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
 import com.android.tools.smali.dexlib2.iface.reference.MethodReference
+import patches.universal.ads.util.findMutableMethodOf
 import java.util.logging.Logger
 
 @Suppress("unused")
@@ -30,8 +31,9 @@ val fakeBatteryWhitelistPatch = bytecodePatch(
 
         var patched = 0
         classDefForEach { classDef ->
-            val mutableClass = mutableClassDefBy(classDef)
-            for (method in mutableClass.methods) {
+            val mutableClass by lazy { mutableClassDefBy(classDef) }
+            for (method in classDef.methods) {
+                val mutableMethod by lazy { mutableClass.findMutableMethodOf(method) }
                 val implementation = method.implementation ?: continue
                 // Snapshot; one-for-one replacements keep indices valid.
                 val instructions = implementation.instructions.toList()
@@ -49,10 +51,10 @@ val fakeBatteryWhitelistPatch = bytecodePatch(
 
                     val next = instructions.getOrNull(index + 1) as? OneRegisterInstruction
                     if (next != null && next.opcode == Opcode.MOVE_RESULT) {
-                        method.replaceInstruction(index, "const/4 v${next.registerA}, $target")
-                        method.replaceInstruction(index + 1, "nop")
+                        mutableMethod.replaceInstruction(index, "const/4 v${next.registerA}, $target")
+                        mutableMethod.replaceInstruction(index + 1, "nop")
                     } else {
-                        method.replaceInstruction(index, "nop")
+                        mutableMethod.replaceInstruction(index, "nop")
                     }
                     patched++
                 }

--- a/patches/src/main/kotlin/patches/universal/misc/FakeBrightnessAutoModePatch.kt
+++ b/patches/src/main/kotlin/patches/universal/misc/FakeBrightnessAutoModePatch.kt
@@ -1,8 +1,8 @@
 package patches.universal.misc
 
 import app.morphe.patcher.extensions.InstructionExtensions.replaceInstruction
-import app.morphe.patcher.patch.bytecodePatch
 import app.morphe.patcher.patch.booleanOption
+import app.morphe.patcher.patch.bytecodePatch
 import com.android.tools.smali.dexlib2.Opcode
 import com.android.tools.smali.dexlib2.builder.instruction.BuilderInstruction35c
 import com.android.tools.smali.dexlib2.builder.instruction.BuilderInstruction3rc
@@ -11,6 +11,7 @@ import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
 import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
 import com.android.tools.smali.dexlib2.iface.reference.MethodReference
 import com.android.tools.smali.dexlib2.iface.reference.StringReference
+import patches.universal.ads.util.findMutableMethodOf
 import java.util.logging.Logger
 
 @Suppress("unused")
@@ -32,8 +33,9 @@ val fakeBrightnessAutoModePatch = bytecodePatch(
 
         var patched = 0
         classDefForEach { classDef ->
-            val mutableClass = mutableClassDefBy(classDef)
-            for (method in mutableClass.methods) {
+            val mutableClass by lazy { mutableClassDefBy(classDef) }
+            for (method in classDef.methods) {
+                val mutableMethod by lazy { mutableClass.findMutableMethodOf(method) }
                 val implementation = method.implementation ?: continue
                 val instructions: List<Instruction> = implementation.instructions.toList()
                 for ((index, instruction) in instructions.withIndex()) {
@@ -71,8 +73,8 @@ val fakeBrightnessAutoModePatch = bytecodePatch(
                     val next = instructions.getOrNull(index + 1)
                     if (next != null && next.opcode == Opcode.MOVE_RESULT) {
                         val resultRegister = (next as OneRegisterInstruction).registerA
-                        method.replaceInstruction(index, "const/4 v$resultRegister, $target")
-                        method.replaceInstruction(index + 1, "nop")
+                        mutableMethod.replaceInstruction(index, "const/4 v$resultRegister, $target")
+                        mutableMethod.replaceInstruction(index + 1, "nop")
                         patched++
                     }
                 }

--- a/patches/src/main/kotlin/patches/universal/misc/FakeDozeAlwaysOnPatch.kt
+++ b/patches/src/main/kotlin/patches/universal/misc/FakeDozeAlwaysOnPatch.kt
@@ -1,8 +1,8 @@
 package patches.universal.misc
 
 import app.morphe.patcher.extensions.InstructionExtensions.replaceInstruction
-import app.morphe.patcher.patch.bytecodePatch
 import app.morphe.patcher.patch.booleanOption
+import app.morphe.patcher.patch.bytecodePatch
 import com.android.tools.smali.dexlib2.Opcode
 import com.android.tools.smali.dexlib2.builder.instruction.BuilderInstruction35c
 import com.android.tools.smali.dexlib2.builder.instruction.BuilderInstruction3rc
@@ -11,6 +11,7 @@ import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
 import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
 import com.android.tools.smali.dexlib2.iface.reference.MethodReference
 import com.android.tools.smali.dexlib2.iface.reference.StringReference
+import patches.universal.ads.util.findMutableMethodOf
 import java.util.logging.Logger
 
 @Suppress("unused")
@@ -32,8 +33,9 @@ val fakeDozeAlwaysOnPatch = bytecodePatch(
 
         var patched = 0
         classDefForEach { classDef ->
-            val mutableClass = mutableClassDefBy(classDef)
-            for (method in mutableClass.methods) {
+            val mutableClass by lazy { mutableClassDefBy(classDef) }
+            for (method in classDef.methods) {
+                val mutableMethod by lazy { mutableClass.findMutableMethodOf(method) }
                 val implementation = method.implementation ?: continue
                 val instructions: List<Instruction> = implementation.instructions.toList()
                 for ((index, instruction) in instructions.withIndex()) {
@@ -71,8 +73,8 @@ val fakeDozeAlwaysOnPatch = bytecodePatch(
                     val next = instructions.getOrNull(index + 1)
                     if (next != null && next.opcode == Opcode.MOVE_RESULT) {
                         val resultRegister = (next as OneRegisterInstruction).registerA
-                        method.replaceInstruction(index, "const/4 v$resultRegister, $target")
-                        method.replaceInstruction(index + 1, "nop")
+                        mutableMethod.replaceInstruction(index, "const/4 v$resultRegister, $target")
+                        mutableMethod.replaceInstruction(index + 1, "nop")
                         patched++
                     }
                 }

--- a/patches/src/main/kotlin/patches/universal/misc/FakeDtmfToneEnabledPatch.kt
+++ b/patches/src/main/kotlin/patches/universal/misc/FakeDtmfToneEnabledPatch.kt
@@ -11,6 +11,7 @@ import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
 import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
 import com.android.tools.smali.dexlib2.iface.reference.MethodReference
 import com.android.tools.smali.dexlib2.iface.reference.StringReference
+import patches.universal.ads.util.findMutableMethodOf
 import java.util.logging.Logger
 
 @Suppress("unused")
@@ -32,8 +33,9 @@ val fakeDtmfToneEnabledPatch = bytecodePatch(
 
         var patched = 0
         classDefForEach { classDef ->
-            val mutableClass = mutableClassDefBy(classDef)
-            for (method in mutableClass.methods) {
+            val mutableClass by lazy { mutableClassDefBy(classDef) }
+            for (method in classDef.methods) {
+                val mutableMethod by lazy { mutableClass.findMutableMethodOf(method) }
                 val implementation = method.implementation ?: continue
                 val instructions: List<Instruction> = implementation.instructions.toList()
                 for ((index, instruction) in instructions.withIndex()) {
@@ -71,8 +73,8 @@ val fakeDtmfToneEnabledPatch = bytecodePatch(
                     val next = instructions.getOrNull(index + 1)
                     if (next != null && next.opcode == Opcode.MOVE_RESULT) {
                         val resultRegister = (next as OneRegisterInstruction).registerA
-                        method.replaceInstruction(index, "const/4 v$resultRegister, $target")
-                        method.replaceInstruction(index + 1, "nop")
+                        mutableMethod.replaceInstruction(index, "const/4 v$resultRegister, $target")
+                        mutableMethod.replaceInstruction(index + 1, "nop")
                         patched++
                     }
                 }

--- a/patches/src/main/kotlin/patches/universal/misc/FakeFontScalePatch.kt
+++ b/patches/src/main/kotlin/patches/universal/misc/FakeFontScalePatch.kt
@@ -11,6 +11,7 @@ import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
 import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
 import com.android.tools.smali.dexlib2.iface.reference.MethodReference
 import com.android.tools.smali.dexlib2.iface.reference.StringReference
+import patches.universal.ads.util.findMutableMethodOf
 import java.util.logging.Logger
 
 @Suppress("unused")
@@ -37,8 +38,9 @@ val fakeFontScalePatch = bytecodePatch(
 
         var patched = 0
         classDefForEach { classDef ->
-            val mutableClass = mutableClassDefBy(classDef)
-            for (method in mutableClass.methods) {
+            val mutableClass by lazy { mutableClassDefBy(classDef) }
+            for (method in classDef.methods) {
+                val mutableMethod by lazy { mutableClass.findMutableMethodOf(method) }
                 val implementation = method.implementation ?: continue
                 val instructions: List<Instruction> = implementation.instructions.toList()
                 for ((index, instruction) in instructions.withIndex()) {
@@ -76,8 +78,8 @@ val fakeFontScalePatch = bytecodePatch(
                     val next = instructions.getOrNull(index + 1)
                     if (next != null && next.opcode == Opcode.MOVE_RESULT) {
                         val resultRegister = (next as OneRegisterInstruction).registerA
-                        method.replaceInstruction(index, "const/high16 v$resultRegister, $hex")
-                        method.replaceInstruction(index + 1, "nop")
+                        mutableMethod.replaceInstruction(index, "const/high16 v$resultRegister, $hex")
+                        mutableMethod.replaceInstruction(index + 1, "nop")
                         patched++
                     }
                 }

--- a/patches/src/main/kotlin/patches/universal/misc/FakeLocationAccuracyPatch.kt
+++ b/patches/src/main/kotlin/patches/universal/misc/FakeLocationAccuracyPatch.kt
@@ -8,6 +8,7 @@ import com.android.tools.smali.dexlib2.iface.instruction.Instruction
 import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
 import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
 import com.android.tools.smali.dexlib2.iface.reference.MethodReference
+import patches.universal.ads.util.findMutableMethodOf
 import java.util.logging.Logger
 
 @Suppress("unused")
@@ -31,8 +32,9 @@ val fakeLocationAccuracyPatch = bytecodePatch(
 
         var patched = 0
         classDefForEach { classDef ->
-            val mutableClass = mutableClassDefBy(classDef)
-            for (method in mutableClass.methods) {
+            val mutableClass by lazy { mutableClassDefBy(classDef) }
+            for (method in classDef.methods) {
+                val mutableMethod by lazy { mutableClass.findMutableMethodOf(method) }
                 val implementation = method.implementation ?: continue
                 val instructions: List<Instruction> = implementation.instructions.toList()
                 for ((index, instruction) in instructions.withIndex()) {
@@ -47,8 +49,8 @@ val fakeLocationAccuracyPatch = bytecodePatch(
                     val next = instructions.getOrNull(index + 1)
                     if (next != null && next.opcode == Opcode.MOVE_RESULT) {
                         val resultRegister = (next as OneRegisterInstruction).registerA
-                        method.replaceInstruction(index, "const/high16 v$resultRegister, $hex")
-                        method.replaceInstruction(index + 1, "nop")
+                        mutableMethod.replaceInstruction(index, "const/high16 v$resultRegister, $hex")
+                        mutableMethod.replaceInstruction(index + 1, "nop")
                         patched++
                     }
                 }

--- a/patches/src/main/kotlin/patches/universal/misc/FakeOnlineStatePatch.kt
+++ b/patches/src/main/kotlin/patches/universal/misc/FakeOnlineStatePatch.kt
@@ -6,6 +6,7 @@ import com.android.tools.smali.dexlib2.Opcode
 import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
 import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
 import com.android.tools.smali.dexlib2.iface.reference.MethodReference
+import patches.universal.ads.util.findMutableMethodOf
 import java.util.logging.Logger
 
 @Suppress("unused")
@@ -32,8 +33,9 @@ val fakeOnlineStatePatch = bytecodePatch(
 
         var patched = 0
         classDefForEach { classDef ->
-            val mutableClass = mutableClassDefBy(classDef)
-            for (method in mutableClass.methods) {
+            val mutableClass by lazy { mutableClassDefBy(classDef) }
+            for (method in classDef.methods) {
+                val mutableMethod by lazy { mutableClass.findMutableMethodOf(method) }
                 val implementation = method.implementation ?: continue
                 // Snapshot; one-for-one replacements keep indices valid.
                 val instructions = implementation.instructions.toList()
@@ -46,11 +48,11 @@ val fakeOnlineStatePatch = bytecodePatch(
                     val next = instructions.getOrNull(index + 1) as? OneRegisterInstruction
                     if (next != null && next.opcode == Opcode.MOVE_RESULT) {
                         // Fold invoke + move-result into a single constant.
-                        method.replaceInstruction(index, "const/4 v${next.registerA}, 0x1")
-                        method.replaceInstruction(index + 1, "nop")
+                        mutableMethod.replaceInstruction(index, "const/4 v${next.registerA}, 0x1")
+                        mutableMethod.replaceInstruction(index + 1, "nop")
                     } else {
                         // Result unused: dropping the call entirely is safe.
-                        method.replaceInstruction(index, "nop")
+                        mutableMethod.replaceInstruction(index, "nop")
                     }
                     patched++
                 }

--- a/patches/src/main/kotlin/patches/universal/misc/FakePointerLocationPatch.kt
+++ b/patches/src/main/kotlin/patches/universal/misc/FakePointerLocationPatch.kt
@@ -11,6 +11,7 @@ import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
 import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
 import com.android.tools.smali.dexlib2.iface.reference.MethodReference
 import com.android.tools.smali.dexlib2.iface.reference.StringReference
+import patches.universal.ads.util.findMutableMethodOf
 import java.util.logging.Logger
 
 @Suppress("unused")
@@ -31,8 +32,9 @@ val fakePointerLocationPatch = bytecodePatch(
         val target = if (enabled == true) 1 else 0
         var patched = 0
         classDefForEach { classDef ->
-            val mutableClass = mutableClassDefBy(classDef)
-            for (method in mutableClass.methods) {
+            val mutableClass by lazy { mutableClassDefBy(classDef) }
+            for (method in classDef.methods) {
+                val mutableMethod by lazy { mutableClass.findMutableMethodOf(method) }
                 val impl = method.implementation ?: continue
                 val instructions: List<Instruction> = impl.instructions.toList()
                 for ((index, insn) in instructions.withIndex()) {
@@ -62,8 +64,8 @@ val fakePointerLocationPatch = bytecodePatch(
                     val next = instructions.getOrNull(index + 1)
                     if (next != null && next.opcode == Opcode.MOVE_RESULT) {
                         val resultRegister = (next as OneRegisterInstruction).registerA
-                        method.replaceInstruction(index, "const/4 v$resultRegister, $target")
-                        method.replaceInstruction(index + 1, "nop")
+                        mutableMethod.replaceInstruction(index, "const/4 v$resultRegister, $target")
+                        mutableMethod.replaceInstruction(index + 1, "nop")
                         patched++
                     }
                 }

--- a/patches/src/main/kotlin/patches/universal/misc/FakeScreenTimeoutPatch.kt
+++ b/patches/src/main/kotlin/patches/universal/misc/FakeScreenTimeoutPatch.kt
@@ -11,6 +11,7 @@ import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
 import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
 import com.android.tools.smali.dexlib2.iface.reference.MethodReference
 import com.android.tools.smali.dexlib2.iface.reference.StringReference
+import patches.universal.ads.util.findMutableMethodOf
 import java.util.logging.Logger
 
 @Suppress("unused")
@@ -32,8 +33,9 @@ val fakeScreenTimeoutPatch = bytecodePatch(
 
         var patched = 0
         classDefForEach { classDef ->
-            val mutableClass = mutableClassDefBy(classDef)
-            for (method in mutableClass.methods) {
+            val mutableClass by lazy { mutableClassDefBy(classDef) }
+            for (method in classDef.methods) {
+                val mutableMethod by lazy { mutableClass.findMutableMethodOf(method) }
                 val implementation = method.implementation ?: continue
                 val instructions: List<Instruction> = implementation.instructions.toList()
                 for ((index, instruction) in instructions.withIndex()) {
@@ -71,8 +73,8 @@ val fakeScreenTimeoutPatch = bytecodePatch(
                     val next = instructions.getOrNull(index + 1)
                     if (next != null && next.opcode == Opcode.MOVE_RESULT) {
                         val resultRegister = (next as OneRegisterInstruction).registerA
-                        method.replaceInstruction(index, "const v$resultRegister, $timeout")
-                        method.replaceInstruction(index + 1, "nop")
+                        mutableMethod.replaceInstruction(index, "const v$resultRegister, $timeout")
+                        mutableMethod.replaceInstruction(index + 1, "nop")
                         patched++
                     }
                 }

--- a/patches/src/main/kotlin/patches/universal/misc/FakeShowTouchesPatch.kt
+++ b/patches/src/main/kotlin/patches/universal/misc/FakeShowTouchesPatch.kt
@@ -11,6 +11,7 @@ import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
 import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
 import com.android.tools.smali.dexlib2.iface.reference.MethodReference
 import com.android.tools.smali.dexlib2.iface.reference.StringReference
+import patches.universal.ads.util.findMutableMethodOf
 import java.util.logging.Logger
 
 @Suppress("unused")
@@ -31,8 +32,9 @@ val fakeShowTouchesPatch = bytecodePatch(
         val target = if (enabled == true) 1 else 0
         var patched = 0
         classDefForEach { classDef ->
-            val mutableClass = mutableClassDefBy(classDef)
-            for (method in mutableClass.methods) {
+            val mutableClass by lazy { mutableClassDefBy(classDef) }
+            for (method in classDef.methods) {
+                val mutableMethod by lazy { mutableClass.findMutableMethodOf(method) }
                 val impl = method.implementation ?: continue
                 val instructions: List<Instruction> = impl.instructions.toList()
                 for ((index, insn) in instructions.withIndex()) {
@@ -62,8 +64,8 @@ val fakeShowTouchesPatch = bytecodePatch(
                     val next = instructions.getOrNull(index + 1)
                     if (next != null && next.opcode == Opcode.MOVE_RESULT) {
                         val resultRegister = (next as OneRegisterInstruction).registerA
-                        method.replaceInstruction(index, "const/4 v$resultRegister, $target")
-                        method.replaceInstruction(index + 1, "nop")
+                        mutableMethod.replaceInstruction(index, "const/4 v$resultRegister, $target")
+                        mutableMethod.replaceInstruction(index + 1, "nop")
                         patched++
                     }
                 }

--- a/patches/src/main/kotlin/patches/universal/misc/FakeSoundEffectsEnabledPatch.kt
+++ b/patches/src/main/kotlin/patches/universal/misc/FakeSoundEffectsEnabledPatch.kt
@@ -11,6 +11,7 @@ import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
 import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
 import com.android.tools.smali.dexlib2.iface.reference.MethodReference
 import com.android.tools.smali.dexlib2.iface.reference.StringReference
+import patches.universal.ads.util.findMutableMethodOf
 import java.util.logging.Logger
 
 @Suppress("unused")
@@ -31,8 +32,9 @@ val fakeSoundEffectsEnabledPatch = bytecodePatch(
         val target = if (enabled == true) 1 else 0
         var patched = 0
         classDefForEach { classDef ->
-            val mutableClass = mutableClassDefBy(classDef)
-            for (method in mutableClass.methods) {
+            val mutableClass by lazy { mutableClassDefBy(classDef) }
+            for (method in classDef.methods) {
+                val mutableMethod by lazy { mutableClass.findMutableMethodOf(method) }
                 val impl = method.implementation ?: continue
                 val instructions: List<Instruction> = impl.instructions.toList()
                 for ((index, insn) in instructions.withIndex()) {
@@ -62,8 +64,8 @@ val fakeSoundEffectsEnabledPatch = bytecodePatch(
                     val next = instructions.getOrNull(index + 1)
                     if (next != null && next.opcode == Opcode.MOVE_RESULT) {
                         val resultRegister = (next as OneRegisterInstruction).registerA
-                        method.replaceInstruction(index, "const/4 v$resultRegister, $target")
-                        method.replaceInstruction(index + 1, "nop")
+                        mutableMethod.replaceInstruction(index, "const/4 v$resultRegister, $target")
+                        mutableMethod.replaceInstruction(index + 1, "nop")
                         patched++
                     }
                 }

--- a/patches/src/main/kotlin/patches/universal/misc/FakeStayOnWhilePluggedPatch.kt
+++ b/patches/src/main/kotlin/patches/universal/misc/FakeStayOnWhilePluggedPatch.kt
@@ -11,7 +11,7 @@ import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
 import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
 import com.android.tools.smali.dexlib2.iface.reference.MethodReference
 import com.android.tools.smali.dexlib2.iface.reference.StringReference
-import java.util.LinkedHashMap
+import patches.universal.ads.util.findMutableMethodOf
 import java.util.logging.Logger
 
 @Suppress("unused")
@@ -41,8 +41,9 @@ val fakeStayOnWhilePluggedPatch = bytecodePatch(
 
         var patched = 0
         classDefForEach { classDef ->
-            val mutableClass = mutableClassDefBy(classDef)
-            for (method in mutableClass.methods) {
+            val mutableClass by lazy { mutableClassDefBy(classDef) }
+            for (method in classDef.methods) {
+                val mutableMethod by lazy { mutableClass.findMutableMethodOf(method) }
                 val implementation = method.implementation ?: continue
                 val instructions: List<Instruction> = implementation.instructions.toList()
                 for ((index, instruction) in instructions.withIndex()) {
@@ -80,8 +81,8 @@ val fakeStayOnWhilePluggedPatch = bytecodePatch(
                     val next = instructions.getOrNull(index + 1)
                     if (next != null && next.opcode == Opcode.MOVE_RESULT) {
                         val resultRegister = (next as OneRegisterInstruction).registerA
-                        method.replaceInstruction(index, "const/4 v$resultRegister, $target")
-                        method.replaceInstruction(index + 1, "nop")
+                        mutableMethod.replaceInstruction(index, "const/4 v$resultRegister, $target")
+                        mutableMethod.replaceInstruction(index + 1, "nop")
                         patched++
                     }
                 }

--- a/patches/src/main/kotlin/patches/universal/misc/FakeStorageAvailablePatch.kt
+++ b/patches/src/main/kotlin/patches/universal/misc/FakeStorageAvailablePatch.kt
@@ -8,6 +8,7 @@ import com.android.tools.smali.dexlib2.iface.instruction.Instruction
 import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
 import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
 import com.android.tools.smali.dexlib2.iface.reference.MethodReference
+import patches.universal.ads.util.findMutableMethodOf
 import java.util.logging.Logger
 
 @Suppress("unused")
@@ -35,8 +36,9 @@ val fakeStorageAvailablePatch = bytecodePatch(
         )
         var patched = 0
         classDefForEach { classDef ->
-            val mutableClass = mutableClassDefBy(classDef)
-            for (method in mutableClass.methods) {
+            val mutableClass by lazy { mutableClassDefBy(classDef) }
+            for (method in classDef.methods) {
+                val mutableMethod by lazy { mutableClass.findMutableMethodOf(method) }
                 val implementation = method.implementation ?: continue
                 // Snapshot; one-for-one replacements keep indices valid.
                 val instructions: List<Instruction> = implementation.instructions.toList()
@@ -56,8 +58,8 @@ val fakeStorageAvailablePatch = bytecodePatch(
                         } else {
                             "const-wide v$resultRegister, $hex"
                         }
-                        method.replaceInstruction(index, replacement)
-                        method.replaceInstruction(index + 1, "nop")
+                        mutableMethod.replaceInstruction(index, replacement)
+                        mutableMethod.replaceInstruction(index + 1, "nop")
                         patched++
                     }
                 }

--- a/patches/src/main/kotlin/patches/universal/misc/FakeVibrateWhenRingingPatch.kt
+++ b/patches/src/main/kotlin/patches/universal/misc/FakeVibrateWhenRingingPatch.kt
@@ -11,6 +11,7 @@ import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
 import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
 import com.android.tools.smali.dexlib2.iface.reference.MethodReference
 import com.android.tools.smali.dexlib2.iface.reference.StringReference
+import patches.universal.ads.util.findMutableMethodOf
 import java.util.logging.Logger
 
 @Suppress("unused")
@@ -32,8 +33,9 @@ val fakeVibrateWhenRingingPatch = bytecodePatch(
 
         var patched = 0
         classDefForEach { classDef ->
-            val mutableClass = mutableClassDefBy(classDef)
-            for (method in mutableClass.methods) {
+            val mutableClass by lazy { mutableClassDefBy(classDef) }
+            for (method in classDef.methods) {
+                val mutableMethod by lazy { mutableClass.findMutableMethodOf(method) }
                 val implementation = method.implementation ?: continue
                 val instructions: List<Instruction> = implementation.instructions.toList()
                 for ((index, instruction) in instructions.withIndex()) {
@@ -71,8 +73,8 @@ val fakeVibrateWhenRingingPatch = bytecodePatch(
                     val next = instructions.getOrNull(index + 1)
                     if (next != null && next.opcode == Opcode.MOVE_RESULT) {
                         val resultRegister = (next as OneRegisterInstruction).registerA
-                        method.replaceInstruction(index, "const/4 v$resultRegister, $target")
-                        method.replaceInstruction(index + 1, "nop")
+                        mutableMethod.replaceInstruction(index, "const/4 v$resultRegister, $target")
+                        mutableMethod.replaceInstruction(index + 1, "nop")
                         patched++
                     }
                 }

--- a/patches/src/main/kotlin/patches/universal/misc/FoldBooleanReturns.kt
+++ b/patches/src/main/kotlin/patches/universal/misc/FoldBooleanReturns.kt
@@ -6,6 +6,7 @@ import com.android.tools.smali.dexlib2.Opcode
 import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
 import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
 import com.android.tools.smali.dexlib2.iface.reference.MethodReference
+import patches.universal.ads.util.findMutableMethodOf
 
 /**
  * Forces every matching method call to a constant by folding the invoke and its
@@ -33,8 +34,9 @@ internal fun BytecodePatchContext.foldBooleanReturns(
             if (hasRef) break
         }
         if (!hasRef) return@classDefForEach
-        val mutableClass = mutableClassDefBy(classDef)
-        for (method in mutableClass.methods) {
+        val mutableClass by lazy { mutableClassDefBy(classDef) }
+        for (method in classDef.methods) {
+            val mutableMethod by lazy { mutableClass.findMutableMethodOf(method) }
             val implementation = method.implementation ?: continue
             // Snapshot; one-for-one replacements keep indices valid.
             val instructions = implementation.instructions.toList()
@@ -48,10 +50,10 @@ internal fun BytecodePatchContext.foldBooleanReturns(
 
                 val next = instructions.getOrNull(index + 1) as? OneRegisterInstruction
                 if (next != null && next.opcode == Opcode.MOVE_RESULT) {
-                    method.replaceInstruction(index, "const/4 v${next.registerA}, $value")
-                    method.replaceInstruction(index + 1, "nop")
+                    mutableMethod.replaceInstruction(index, "const/4 v${next.registerA}, $value")
+                    mutableMethod.replaceInstruction(index + 1, "nop")
                 } else {
-                    method.replaceInstruction(index, "nop")
+                    mutableMethod.replaceInstruction(index, "nop")
                 }
                 patched++
             }

--- a/patches/src/main/kotlin/patches/universal/misc/ForceBatteryHealthGoodPatch.kt
+++ b/patches/src/main/kotlin/patches/universal/misc/ForceBatteryHealthGoodPatch.kt
@@ -11,6 +11,7 @@ import com.android.tools.smali.dexlib2.iface.instruction.NarrowLiteralInstructio
 import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
 import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
 import com.android.tools.smali.dexlib2.iface.reference.MethodReference
+import patches.universal.ads.util.findMutableMethodOf
 import java.util.logging.Logger
 
 @Suppress("unused")
@@ -38,8 +39,9 @@ val forceBatteryHealthGoodPatch = bytecodePatch(
         val target = (health ?: "2").toIntOrNull() ?: 2
         var patched = 0
         classDefForEach { classDef ->
-            val mutableClass = mutableClassDefBy(classDef)
-            for (method in mutableClass.methods) {
+            val mutableClass by lazy { mutableClassDefBy(classDef) }
+            for (method in classDef.methods) {
+                val mutableMethod by lazy { mutableClass.findMutableMethodOf(method) }
                 val impl = method.implementation ?: continue
                 val instructions: List<Instruction> = impl.instructions.toList()
                 for ((index, insn) in instructions.withIndex()) {
@@ -66,8 +68,8 @@ val forceBatteryHealthGoodPatch = bytecodePatch(
                     val next = instructions.getOrNull(index + 1)
                     if (next != null && next.opcode == Opcode.MOVE_RESULT) {
                         val resultRegister = (next as OneRegisterInstruction).registerA
-                        method.replaceInstruction(index, "const/4 v$resultRegister, $target")
-                        method.replaceInstruction(index + 1, "nop")
+                        mutableMethod.replaceInstruction(index, "const/4 v$resultRegister, $target")
+                        mutableMethod.replaceInstruction(index + 1, "nop")
                         patched++
                     }
                 }

--- a/patches/src/main/kotlin/patches/universal/misc/ForceBatteryTemperaturePatch.kt
+++ b/patches/src/main/kotlin/patches/universal/misc/ForceBatteryTemperaturePatch.kt
@@ -11,6 +11,7 @@ import com.android.tools.smali.dexlib2.iface.instruction.NarrowLiteralInstructio
 import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
 import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
 import com.android.tools.smali.dexlib2.iface.reference.MethodReference
+import patches.universal.ads.util.findMutableMethodOf
 import java.util.logging.Logger
 
 @Suppress("unused")
@@ -31,8 +32,9 @@ val forceBatteryTemperaturePatch = bytecodePatch(
         val targetTemp = temperature ?: 250
         var patched = 0
         classDefForEach { classDef ->
-            val mutableClass = mutableClassDefBy(classDef)
-            for (method in mutableClass.methods) {
+            val mutableClass by lazy { mutableClassDefBy(classDef) }
+            for (method in classDef.methods) {
+                val mutableMethod by lazy { mutableClass.findMutableMethodOf(method) }
                 val implementation = method.implementation ?: continue
                 // Snapshot; one-for-one replacements keep indices valid.
                 val instructions: List<Instruction> = implementation.instructions.toList()
@@ -70,12 +72,12 @@ val forceBatteryTemperaturePatch = bytecodePatch(
                     val next = instructions.getOrNull(index + 1)
                     if (next != null && next.opcode == Opcode.MOVE_RESULT) {
                         val resultRegister = (next as OneRegisterInstruction).registerA
-                        method.replaceInstruction(index, if (resultRegister <= 0xff) {
+                        mutableMethod.replaceInstruction(index, if (resultRegister <= 0xff) {
                             "const/16 v$resultRegister, $targetTemp"
                         } else {
                             "const v$resultRegister, $targetTemp"
                         })
-                        method.replaceInstruction(index + 1, "nop")
+                        mutableMethod.replaceInstruction(index + 1, "nop")
                         patched++
                     }
                 }

--- a/patches/src/main/kotlin/patches/universal/misc/ForceChargingStatusPatch.kt
+++ b/patches/src/main/kotlin/patches/universal/misc/ForceChargingStatusPatch.kt
@@ -11,6 +11,7 @@ import com.android.tools.smali.dexlib2.iface.instruction.NarrowLiteralInstructio
 import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
 import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
 import com.android.tools.smali.dexlib2.iface.reference.MethodReference
+import patches.universal.ads.util.findMutableMethodOf
 import java.util.logging.Logger
 
 @Suppress("unused")
@@ -37,8 +38,9 @@ val forceChargingStatusPatch = bytecodePatch(
         val target = status?.toIntOrNull() ?: 2
         var patched = 0
         classDefForEach { classDef ->
-            val mutableClass = mutableClassDefBy(classDef)
-            for (method in mutableClass.methods) {
+            val mutableClass by lazy { mutableClassDefBy(classDef) }
+            for (method in classDef.methods) {
+                val mutableMethod by lazy { mutableClass.findMutableMethodOf(method) }
                 val implementation = method.implementation ?: continue
                 // Snapshot; one-for-one replacements keep indices valid.
                 val instructions: List<Instruction> = implementation.instructions.toList()
@@ -76,12 +78,12 @@ val forceChargingStatusPatch = bytecodePatch(
                     val next = instructions.getOrNull(index + 1)
                     if (next != null && next.opcode == Opcode.MOVE_RESULT) {
                         val resultRegister = (next as OneRegisterInstruction).registerA
-                        method.replaceInstruction(index, if (resultRegister <= 0xff) {
+                        mutableMethod.replaceInstruction(index, if (resultRegister <= 0xff) {
                             "const/4 v$resultRegister, $target"
                         } else {
                             "const/16 v$resultRegister, $target"
                         })
-                        method.replaceInstruction(index + 1, "nop")
+                        mutableMethod.replaceInstruction(index + 1, "nop")
                         patched++
                     }
                 }

--- a/patches/src/main/kotlin/patches/universal/misc/ForceMaxBrightnessPatch.kt
+++ b/patches/src/main/kotlin/patches/universal/misc/ForceMaxBrightnessPatch.kt
@@ -6,11 +6,11 @@ import app.morphe.patcher.patch.intOption
 import com.android.tools.smali.dexlib2.Opcode
 import com.android.tools.smali.dexlib2.builder.instruction.BuilderInstruction35c
 import com.android.tools.smali.dexlib2.builder.instruction.BuilderInstruction3rc
-import com.android.tools.smali.dexlib2.iface.instruction.Instruction
 import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
 import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
 import com.android.tools.smali.dexlib2.iface.reference.MethodReference
 import com.android.tools.smali.dexlib2.iface.reference.StringReference
+import patches.universal.ads.util.findMutableMethodOf
 import java.util.logging.Logger
 
 @Suppress("unused")
@@ -31,8 +31,9 @@ val forceMaxBrightnessPatch = bytecodePatch(
         val target = (brightness ?: 255).coerceIn(0, 255)
         var patched = 0
         classDefForEach { classDef ->
-            val mutableClass = mutableClassDefBy(classDef)
-            for (method in mutableClass.methods) {
+            val mutableClass by lazy { mutableClassDefBy(classDef) }
+            for (method in classDef.methods) {
+                val mutableMethod by lazy { mutableClass.findMutableMethodOf(method) }
                 val implementation = method.implementation ?: continue
                 // Snapshot; one-for-one replacements keep indices valid.
                 val instructions = implementation.instructions.toList()
@@ -76,11 +77,11 @@ val forceMaxBrightnessPatch = bytecodePatch(
                         } else {
                             "const v$resultRegister, $target"
                         }
-                        method.replaceInstruction(index, const)
-                        method.replaceInstruction(index + 1, "nop")
+                        mutableMethod.replaceInstruction(index, const)
+                        mutableMethod.replaceInstruction(index + 1, "nop")
                         patched++
                     } else {
-                        method.replaceInstruction(index, "nop")
+                        mutableMethod.replaceInstruction(index, "nop")
                     }
                 }
             }

--- a/patches/src/main/kotlin/patches/universal/misc/GetterSpoofer.kt
+++ b/patches/src/main/kotlin/patches/universal/misc/GetterSpoofer.kt
@@ -12,6 +12,7 @@ import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
 import com.android.tools.smali.dexlib2.iface.reference.FieldReference
 import com.android.tools.smali.dexlib2.iface.reference.MethodReference
 import com.android.tools.smali.dexlib2.iface.reference.StringReference
+import patches.universal.ads.util.findMutableMethodOf
 
 private fun escapeSmali(value: String): String =
     value
@@ -65,8 +66,9 @@ internal fun BytecodePatchContext.foldSettingsGetterConst(
             if (hasRef) break
         }
         if (!hasRef) return@classDefForEach
-        val mutableClass = mutableClassDefBy(classDef)
-        for (method in mutableClass.methods) {
+        val mutableClass by lazy { mutableClassDefBy(classDef) }
+        for (method in classDef.methods) {
+            val mutableMethod by lazy { mutableClass.findMutableMethodOf(method) }
             val implementation = method.implementation ?: continue
             // Snapshot; one-for-one replacements keep indices valid.
             val instructions: List<Instruction> = implementation.instructions.toList()
@@ -145,10 +147,10 @@ internal fun BytecodePatchContext.foldSettingsGetterConst(
                         }
                         else -> constString(resultRegister, stringValue)
                     }
-                    method.replaceInstruction(index, replacement)
-                    method.replaceInstruction(index + 1, "nop")
+                    mutableMethod.replaceInstruction(index, replacement)
+                    mutableMethod.replaceInstruction(index + 1, "nop")
                 } else {
-                    method.replaceInstruction(index, "nop")
+                    mutableMethod.replaceInstruction(index, "nop")
                 }
                 patched++
             }
@@ -181,8 +183,9 @@ internal fun BytecodePatchContext.foldNoArgStringGetter(
             if (hasRef) break
         }
         if (!hasRef) return@classDefForEach
-        val mutableClass = mutableClassDefBy(classDef)
-        for (method in mutableClass.methods) {
+        val mutableClass by lazy { mutableClassDefBy(classDef) }
+        for (method in classDef.methods) {
+            val mutableMethod by lazy { mutableClass.findMutableMethodOf(method) }
             val implementation = method.implementation ?: continue
             val instructions: List<Instruction> = implementation.instructions.toList()
             for ((index, instruction) in instructions.withIndex()) {
@@ -197,8 +200,8 @@ internal fun BytecodePatchContext.foldNoArgStringGetter(
                 val next = instructions.getOrNull(index + 1)
                 if (next != null && next.opcode == Opcode.MOVE_RESULT_OBJECT) {
                     val resultRegister = (next as OneRegisterInstruction).registerA
-                    method.replaceInstruction(index, constString(resultRegister, value))
-                    method.replaceInstruction(index + 1, "nop")
+                    mutableMethod.replaceInstruction(index, constString(resultRegister, value))
+                    mutableMethod.replaceInstruction(index + 1, "nop")
                     patched++
                 }
             }
@@ -231,8 +234,9 @@ internal fun BytecodePatchContext.foldNoArgIntGetter(
             if (hasRef) break
         }
         if (!hasRef) return@classDefForEach
-        val mutableClass = mutableClassDefBy(classDef)
-        for (method in mutableClass.methods) {
+        val mutableClass by lazy { mutableClassDefBy(classDef) }
+        for (method in classDef.methods) {
+            val mutableMethod by lazy { mutableClass.findMutableMethodOf(method) }
             val implementation = method.implementation ?: continue
             val instructions: List<Instruction> = implementation.instructions.toList()
             for ((index, instruction) in instructions.withIndex()) {
@@ -252,8 +256,8 @@ internal fun BytecodePatchContext.foldNoArgIntGetter(
                     } else {
                         "const/16 v$resultRegister, $value"
                     }
-                    method.replaceInstruction(index, const)
-                    method.replaceInstruction(index + 1, "nop")
+                    mutableMethod.replaceInstruction(index, const)
+                    mutableMethod.replaceInstruction(index + 1, "nop")
                     patched++
                 }
             }
@@ -285,8 +289,9 @@ internal fun BytecodePatchContext.foldLocaleGetDefault(tag: String): Int {
             if (hasRef) break
         }
         if (!hasRef) return@classDefForEach
-        val mutableClass = mutableClassDefBy(classDef)
-        for (method in mutableClass.methods) {
+        val mutableClass by lazy { mutableClassDefBy(classDef) }
+        for (method in classDef.methods) {
+            val mutableMethod by lazy { mutableClass.findMutableMethodOf(method) }
             val implementation = method.implementation ?: continue
             val instructions: List<Instruction> = implementation.instructions.toList()
 
@@ -310,11 +315,11 @@ internal fun BytecodePatchContext.foldLocaleGetDefault(tag: String): Int {
             }
 
             for ((index, resultRegister) in matches.asReversed()) {
-                method.replaceInstruction(
+                mutableMethod.replaceInstruction(
                     index,
                     "const-string v$resultRegister, \"${escapeSmali(tag)}\"",
                 )
-                method.addInstruction(
+                mutableMethod.addInstruction(
                     index + 1,
                     "invoke-static {v$resultRegister}, " +
                         "Ljava/util/Locale;->forLanguageTag(Ljava/lang/String;)Ljava/util/Locale;",
@@ -348,8 +353,9 @@ internal fun BytecodePatchContext.foldStringGetterConst(
             if (hasRef) break
         }
         if (!hasRef) return@classDefForEach
-        val mutableClass = mutableClassDefBy(classDef)
-        for (method in mutableClass.methods) {
+        val mutableClass by lazy { mutableClassDefBy(classDef) }
+        for (method in classDef.methods) {
+            val mutableMethod by lazy { mutableClass.findMutableMethodOf(method) }
             val implementation = method.implementation ?: continue
             val instructions: List<Instruction> = implementation.instructions.toList()
             for ((index, instruction) in instructions.withIndex()) {
@@ -363,8 +369,8 @@ internal fun BytecodePatchContext.foldStringGetterConst(
                 val next = instructions.getOrNull(index + 1)
                 if (next != null && next.opcode == Opcode.MOVE_RESULT_OBJECT) {
                     val resultRegister = (next as OneRegisterInstruction).registerA
-                    method.replaceInstruction(index, constString(resultRegister, value))
-                    method.replaceInstruction(index + 1, "nop")
+                    mutableMethod.replaceInstruction(index, constString(resultRegister, value))
+                    mutableMethod.replaceInstruction(index + 1, "nop")
                     patched++
                 }
             }
@@ -394,8 +400,9 @@ internal fun BytecodePatchContext.foldBooleanGetterConst(
             if (hasRef) break
         }
         if (!hasRef) return@classDefForEach
-        val mutableClass = mutableClassDefBy(classDef)
-        for (method in mutableClass.methods) {
+        val mutableClass by lazy { mutableClassDefBy(classDef) }
+        for (method in classDef.methods) {
+            val mutableMethod by lazy { mutableClass.findMutableMethodOf(method) }
             val implementation = method.implementation ?: continue
             val instructions: List<Instruction> = implementation.instructions.toList()
             for ((index, instruction) in instructions.withIndex()) {
@@ -414,8 +421,8 @@ internal fun BytecodePatchContext.foldBooleanGetterConst(
                     } else {
                         "const/4 v$resultRegister, 0x0"
                     }
-                    method.replaceInstruction(index, const)
-                    method.replaceInstruction(index + 1, "nop")
+                    mutableMethod.replaceInstruction(index, const)
+                    mutableMethod.replaceInstruction(index + 1, "nop")
                     patched++
                 }
             }
@@ -446,8 +453,9 @@ internal fun BytecodePatchContext.foldIntGetterConst(
             if (hasRef) break
         }
         if (!hasRef) return@classDefForEach
-        val mutableClass = mutableClassDefBy(classDef)
-        for (method in mutableClass.methods) {
+        val mutableClass by lazy { mutableClassDefBy(classDef) }
+        for (method in classDef.methods) {
+            val mutableMethod by lazy { mutableClass.findMutableMethodOf(method) }
             val implementation = method.implementation ?: continue
             val instructions: List<Instruction> = implementation.instructions.toList()
             for ((index, instruction) in instructions.withIndex()) {
@@ -466,8 +474,8 @@ internal fun BytecodePatchContext.foldIntGetterConst(
                     } else {
                         "const/16 v$resultRegister, 0x${value.and(0xffff).toString(16)}"
                     }
-                    method.replaceInstruction(index, const)
-                    method.replaceInstruction(index + 1, "nop")
+                    mutableMethod.replaceInstruction(index, const)
+                    mutableMethod.replaceInstruction(index + 1, "nop")
                     patched++
                 }
             }
@@ -496,8 +504,9 @@ internal fun BytecodePatchContext.foldObjectGetterToNull(
             if (hasRef) break
         }
         if (!hasRef) return@classDefForEach
-        val mutableClass = mutableClassDefBy(classDef)
-        for (method in mutableClass.methods) {
+        val mutableClass by lazy { mutableClassDefBy(classDef) }
+        for (method in classDef.methods) {
+            val mutableMethod by lazy { mutableClass.findMutableMethodOf(method) }
             val implementation = method.implementation ?: continue
             val instructions: List<Instruction> = implementation.instructions.toList()
             for ((index, instruction) in instructions.withIndex()) {
@@ -511,8 +520,8 @@ internal fun BytecodePatchContext.foldObjectGetterToNull(
                 val next = instructions.getOrNull(index + 1)
                 if (next != null && next.opcode == Opcode.MOVE_RESULT_OBJECT) {
                     val resultRegister = (next as OneRegisterInstruction).registerA
-                    method.replaceInstruction(index, "const/4 v$resultRegister, 0x0")
-                    method.replaceInstruction(index + 1, "nop")
+                    mutableMethod.replaceInstruction(index, "const/4 v$resultRegister, 0x0")
+                    mutableMethod.replaceInstruction(index + 1, "nop")
                     patched++
                 }
             }
@@ -545,8 +554,9 @@ internal fun BytecodePatchContext.replaceGetterWithStaticCall(
             if (hasRef) break
         }
         if (!hasRef) return@classDefForEach
-        val mutableClass = mutableClassDefBy(classDef)
-        for (method in mutableClass.methods) {
+        val mutableClass by lazy { mutableClassDefBy(classDef) }
+        for (method in classDef.methods) {
+            val mutableMethod by lazy { mutableClass.findMutableMethodOf(method) }
             val implementation = method.implementation ?: continue
             val instructions: List<Instruction> = implementation.instructions.toList()
             for ((index, instruction) in instructions.withIndex()) {
@@ -559,7 +569,7 @@ internal fun BytecodePatchContext.replaceGetterWithStaticCall(
 
                 val next = instructions.getOrNull(index + 1)
                 if (next != null && next.opcode == Opcode.MOVE_RESULT_OBJECT) {
-                    method.replaceInstruction(index, replacementInvoke)
+                    mutableMethod.replaceInstruction(index, replacementInvoke)
                     patched++
                 }
             }
@@ -592,8 +602,9 @@ internal fun BytecodePatchContext.foldStaticStringField(
             if (hasRef) break
         }
         if (!hasRef) return@classDefForEach
-        val mutableClass = mutableClassDefBy(classDef)
-        for (method in mutableClass.methods) {
+        val mutableClass by lazy { mutableClassDefBy(classDef) }
+        for (method in classDef.methods) {
+            val mutableMethod by lazy { mutableClass.findMutableMethodOf(method) }
             val implementation = method.implementation ?: continue
             val instructions: List<Instruction> = implementation.instructions.toList()
             for ((index, instruction) in instructions.withIndex()) {
@@ -606,7 +617,7 @@ internal fun BytecodePatchContext.foldStaticStringField(
                 val value = values[reference.name] ?: continue
 
                 val register = (instruction as? OneRegisterInstruction)?.registerA ?: continue
-                method.replaceInstruction(
+                mutableMethod.replaceInstruction(
                     index,
                     "const-string v$register, \"${escapeSmali(value)}\"",
                 )

--- a/patches/src/main/kotlin/patches/universal/misc/GrantWebViewGeolocationPatch.kt
+++ b/patches/src/main/kotlin/patches/universal/misc/GrantWebViewGeolocationPatch.kt
@@ -2,6 +2,7 @@ package patches.universal.misc
 
 import app.morphe.patcher.extensions.InstructionExtensions.addInstruction
 import app.morphe.patcher.patch.bytecodePatch
+import patches.universal.ads.util.findMutableMethodOf
 import java.util.logging.Logger
 
 @Suppress("unused")
@@ -14,8 +15,8 @@ val grantWebViewGeolocationPatch = bytecodePatch(
         val logger = Logger.getLogger(this::class.java.name)
         var patched = 0
         classDefForEach { classDef ->
-            val mutableClass = mutableClassDefBy(classDef)
-            for (method in mutableClass.methods) {
+            val mutableClass by lazy { mutableClassDefBy(classDef) }
+            for (method in classDef.methods) {
                 if (method.returnType != "V") continue
                 if (method.name != "onGeolocationPermissionsShowPrompt") continue
                 if (method.parameterTypes != listOf(
@@ -23,14 +24,15 @@ val grantWebViewGeolocationPatch = bytecodePatch(
                         "Landroid/webkit/GeolocationPermissions\$Callback;",
                     )
                 ) continue
-                method.addInstruction(0, "const/4 v0, 0x1")
-                method.addInstruction(1, "const/4 v1, 0x0")
-                method.addInstruction(
+                val mutableMethod = mutableClass.findMutableMethodOf(method)
+                mutableMethod.addInstruction(0, "const/4 v0, 0x1")
+                mutableMethod.addInstruction(1, "const/4 v1, 0x0")
+                mutableMethod.addInstruction(
                     2,
                     "invoke-virtual {p2, p1, v0, v1}, " +
                         "Landroid/webkit/GeolocationPermissions\$Callback;->invoke(Ljava/lang/String;ZZ)V",
                 )
-                method.addInstruction(3, "return-void")
+                mutableMethod.addInstruction(3, "return-void")
                 patched++
             }
         }

--- a/patches/src/main/kotlin/patches/universal/misc/InvokeHelpers.kt
+++ b/patches/src/main/kotlin/patches/universal/misc/InvokeHelpers.kt
@@ -3,14 +3,14 @@ package patches.universal.misc
 import app.morphe.patcher.extensions.InstructionExtensions.addInstruction
 import app.morphe.patcher.extensions.InstructionExtensions.replaceInstruction
 import app.morphe.patcher.patch.BytecodePatchContext
+import com.android.tools.smali.dexlib2.Opcode
 import com.android.tools.smali.dexlib2.builder.instruction.BuilderInstruction35c
 import com.android.tools.smali.dexlib2.builder.instruction.BuilderInstruction3rc
-import com.android.tools.smali.dexlib2.iface.instruction.Instruction
 import com.android.tools.smali.dexlib2.iface.instruction.NarrowLiteralInstruction
 import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
 import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
 import com.android.tools.smali.dexlib2.iface.reference.MethodReference
-import com.android.tools.smali.dexlib2.Opcode
+import patches.universal.ads.util.findMutableMethodOf
 
 private val LOAD_OPCODES = setOf(
     Opcode.CONST, Opcode.CONST_4, Opcode.CONST_16, Opcode.CONST_WIDE,
@@ -33,8 +33,9 @@ internal fun BytecodePatchContext.noOpVoidInvoke(
 ): Int {
     var patched = 0
     classDefForEach { classDef ->
-        val mutableClass = mutableClassDefBy(classDef)
-        for (method in mutableClass.methods) {
+        val mutableClass by lazy { mutableClassDefBy(classDef) }
+        for (method in classDef.methods) {
+            val mutableMethod by lazy { mutableClass.findMutableMethodOf(method) }
             val impl = method.implementation ?: continue
             val instructions = impl.instructions.toList()
             for ((index, insn) in instructions.withIndex()) {
@@ -43,7 +44,7 @@ internal fun BytecodePatchContext.noOpVoidInvoke(
                 if (ref.definingClass != targetClass) continue
                 if (ref.name !in methods) continue
                 if (ref.returnType != "V") continue
-                method.replaceInstruction(index, "nop")
+                mutableMethod.replaceInstruction(index, "nop")
                 patched++
             }
         }
@@ -67,8 +68,9 @@ internal fun BytecodePatchContext.forceNullParam(
 ): Int {
     var patched = 0
     classDefForEach { classDef ->
-        val mutableClass = mutableClassDefBy(classDef)
-        for (method in mutableClass.methods) {
+        val mutableClass by lazy { mutableClassDefBy(classDef) }
+        for (method in classDef.methods) {
+            val mutableMethod by lazy { mutableClass.findMutableMethodOf(method) }
             val impl = method.implementation ?: continue
             val instructions = impl.instructions.toList()
             for ((index, insn) in instructions.withIndex()) {
@@ -88,7 +90,7 @@ internal fun BytecodePatchContext.forceNullParam(
                     prev.registerA == nullReg &&
                     prev.opcode in LOAD_OPCODES
                 ) {
-                    method.replaceInstruction(index - 1, "const/4 v$nullReg, 0x0")
+                    mutableMethod.replaceInstruction(index - 1, "const/4 v$nullReg, 0x0")
                     patched++
                 }
             }
@@ -117,8 +119,9 @@ internal fun BytecodePatchContext.replaceArrayGetterWithEmpty(
 ): Int {
     var patched = 0
     classDefForEach { classDef ->
-        val mutableClass = mutableClassDefBy(classDef)
-        for (method in mutableClass.methods) {
+        val mutableClass by lazy { mutableClassDefBy(classDef) }
+        for (method in classDef.methods) {
+            val mutableMethod by lazy { mutableClass.findMutableMethodOf(method) }
             val impl = method.implementation ?: continue
             val instructions = impl.instructions.toList()
             for ((index, insn) in instructions.withIndex()) {
@@ -132,12 +135,12 @@ internal fun BytecodePatchContext.replaceArrayGetterWithEmpty(
                 if (next !is OneRegisterInstruction || next.opcode != Opcode.MOVE_RESULT_OBJECT) continue
                 val resultReg = next.registerA
 
-                method.replaceInstruction(index, "const/4 v$resultReg, 0x0")
-                method.addInstruction(
+                mutableMethod.replaceInstruction(index, "const/4 v$resultReg, 0x0")
+                mutableMethod.addInstruction(
                     index + 1,
                     "new-array v$resultReg, v$resultReg, [$elementType",
                 )
-                method.replaceInstruction(index + 2, "nop")
+                mutableMethod.replaceInstruction(index + 2, "nop")
                 patched++
             }
         }
@@ -153,8 +156,9 @@ private fun BytecodePatchContext.forceSetterLiteral(
 ): Int {
     var patched = 0
     classDefForEach { classDef ->
-        val mutableClass = mutableClassDefBy(classDef)
-        for (method in mutableClass.methods) {
+        val mutableClass by lazy { mutableClassDefBy(classDef) }
+        for (method in classDef.methods) {
+            val mutableMethod by lazy { mutableClass.findMutableMethodOf(method) }
             val impl = method.implementation ?: continue
             val instructions = impl.instructions.toList()
             for ((index, insn) in instructions.withIndex()) {
@@ -178,7 +182,7 @@ private fun BytecodePatchContext.forceSetterLiteral(
                         prev is OneRegisterInstruction &&
                         prev.registerA == reg
                     ) {
-                        method.replaceInstruction(j, "const/4 v$reg, $literal")
+                        mutableMethod.replaceInstruction(j, "const/4 v$reg, $literal")
                         patched++
                         break
                     }

--- a/patches/src/main/kotlin/patches/universal/misc/SpoofAppSignaturePatch.kt
+++ b/patches/src/main/kotlin/patches/universal/misc/SpoofAppSignaturePatch.kt
@@ -8,6 +8,7 @@ import com.android.tools.smali.dexlib2.Opcode
 import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
 import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
 import com.android.tools.smali.dexlib2.iface.reference.MethodReference
+import patches.universal.ads.util.findMutableMethodOf
 import java.util.logging.Logger
 
 @Suppress("unused")
@@ -40,8 +41,9 @@ val spoofAppSignaturePatch = bytecodePatch(
         val override = packageNameOverride.orEmpty().trim()
 
         classDefForEach { classDef ->
-            val mutableClass = mutableClassDefBy(classDef)
-            for (method in mutableClass.methods) {
+            val mutableClass by lazy { mutableClassDefBy(classDef) }
+            for (method in classDef.methods) {
+                val mutableMethod by lazy { mutableClass.findMutableMethodOf(method) }
                 val impl = method.implementation ?: continue
                 val instructions = impl.instructions.toList()
                 for ((index, insn) in instructions.withIndex()) {
@@ -64,32 +66,13 @@ val spoofAppSignaturePatch = bytecodePatch(
                         val next = instructions.getOrNull(index + 1) as? OneRegisterInstruction
                         if (next != null && next.opcode == Opcode.MOVE_RESULT_OBJECT) {
                             val reg = next.registerA
-                            // const-string vReg, "override"
                             val escaped = override.replace("\\", "\\\\").replace("\"", "\\\"")
-                            method.replaceInstruction(index, "const-string v$reg, \"$escaped\"")
-                            method.replaceInstruction(index + 1, "nop")
-                            // Need to keep original invoke? Actually we replaced invoke with const-string, so nop the invoke and keep move-result as nop
-                            // Our replace above already handled invoke->const, move->nop, so we need to ensure invoke is nop'd
-                            // The loop will handle next iteration, but we already did
+                            mutableMethod.replaceInstruction(index, "const-string v$reg, \"$escaped\"")
+                            mutableMethod.replaceInstruction(index + 1, "nop")
                             patched++
                         }
                         continue
                     }
-
-                    // Signature spoof: for getPackageInfo with signature flags, we want to
-                    // make the returned PackageInfo appear signed with original cert.
-                    // Simplest generic bypass: if the app checks signatures via
-                    // PackageInfo.signatures/signingInfo, we can make the PackageInfo
-                    // field access return a spoofed value. However we don't know the
-                    // original cert, so we hook the field access itself via
-                    // sget/iput? Instead, we hook the method that retrieves PackageInfo
-                    // and clear the signatures field to null, causing most checks
-                    // that do `signatures[0].equals(expected)` to NPE or skip.
-                    // Safer generic: do nothing here and rely on checkSignatures spoof
-                    // already handled by SpoofSignatureMatch. This patch focuses on
-                    // package name override for now; signature spoof via checkSignatures
-                    // is already covered, and full cert spoof would need per-app cert.
-                    // We log that signature spoof is enabled but handled via checkSignatures.
                 }
             }
         }
@@ -98,8 +81,9 @@ val spoofAppSignaturePatch = bytecodePatch(
         if (spoofSignature == true) {
             var sigPatched = 0
             classDefForEach { classDef ->
-                val mutableClass = mutableClassDefBy(classDef)
-                for (method in mutableClass.methods) {
+                val mutableClass by lazy { mutableClassDefBy(classDef) }
+                for (method in classDef.methods) {
+                    val mutableMethod by lazy { mutableClass.findMutableMethodOf(method) }
                     val impl = method.implementation ?: continue
                     val instructions = impl.instructions.toList()
                     for ((index, insn) in instructions.withIndex()) {
@@ -107,11 +91,11 @@ val spoofAppSignaturePatch = bytecodePatch(
                         if (ref.definingClass != "Landroid/content/pm/PackageManager;" || ref.name != "checkSignatures" || ref.returnType != "I") continue
                         val next = instructions.getOrNull(index + 1) as? OneRegisterInstruction
                         if (next != null && next.opcode == Opcode.MOVE_RESULT) {
-                            method.replaceInstruction(index, "const/4 v${next.registerA}, 0x0")
-                            method.replaceInstruction(index + 1, "nop")
+                            mutableMethod.replaceInstruction(index, "const/4 v${next.registerA}, 0x0")
+                            mutableMethod.replaceInstruction(index + 1, "nop")
                             sigPatched++
                         } else {
-                            method.replaceInstruction(index, "nop")
+                            mutableMethod.replaceInstruction(index, "nop")
                             sigPatched++
                         }
                     }

--- a/patches/src/main/kotlin/patches/universal/misc/SpoofBatteryLevelPatch.kt
+++ b/patches/src/main/kotlin/patches/universal/misc/SpoofBatteryLevelPatch.kt
@@ -11,6 +11,7 @@ import com.android.tools.smali.dexlib2.iface.instruction.NarrowLiteralInstructio
 import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
 import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
 import com.android.tools.smali.dexlib2.iface.reference.MethodReference
+import patches.universal.ads.util.findMutableMethodOf
 import java.util.logging.Logger
 
 @Suppress("unused")
@@ -31,8 +32,9 @@ val spoofBatteryLevelPatch = bytecodePatch(
         val target = (level ?: 100).coerceIn(0, 100)
         var patched = 0
         classDefForEach { classDef ->
-            val mutableClass = mutableClassDefBy(classDef)
-            for (method in mutableClass.methods) {
+            val mutableClass by lazy { mutableClassDefBy(classDef) }
+            for (method in classDef.methods) {
+                val mutableMethod by lazy { mutableClass.findMutableMethodOf(method) }
                 val implementation = method.implementation ?: continue
                 // Snapshot; one-for-one replacements keep indices valid.
                 val instructions: List<Instruction> = implementation.instructions.toList()
@@ -77,8 +79,8 @@ val spoofBatteryLevelPatch = bytecodePatch(
                         }
                         // For values > 7 const/4 insufficient; use const/16 path above
                         val insn = if (target in -8..7) const else "const/16 v$resultRegister, $target"
-                        method.replaceInstruction(index, insn)
-                        method.replaceInstruction(index + 1, "nop")
+                        mutableMethod.replaceInstruction(index, insn)
+                        mutableMethod.replaceInstruction(index + 1, "nop")
                         patched++
                     }
                 }

--- a/patches/src/main/kotlin/patches/universal/misc/SpoofBuildFingerprintPatch.kt
+++ b/patches/src/main/kotlin/patches/universal/misc/SpoofBuildFingerprintPatch.kt
@@ -7,6 +7,7 @@ import com.android.tools.smali.dexlib2.Opcode
 import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
 import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
 import com.android.tools.smali.dexlib2.iface.reference.FieldReference
+import patches.universal.ads.util.findMutableMethodOf
 import java.util.logging.Logger
 
 private const val BUILD_CLASS = "Landroid/os/Build;"
@@ -43,8 +44,9 @@ val spoofBuildFingerprintPatch = bytecodePatch(
 
         var patched = 0
         classDefForEach { classDef ->
-            val mutableClass = mutableClassDefBy(classDef)
-            for (method in mutableClass.methods) {
+            val mutableClass by lazy { mutableClassDefBy(classDef) }
+            for (method in classDef.methods) {
+                val mutableMethod by lazy { mutableClass.findMutableMethodOf(method) }
                 val implementation = method.implementation ?: continue
                 // Snapshot; one-for-one replacements keep indices valid.
                 val instructions = implementation.instructions.toList()
@@ -56,11 +58,11 @@ val spoofBuildFingerprintPatch = bytecodePatch(
 
                     val next = instructions.getOrNull(index + 1) as? OneRegisterInstruction
                     if (next != null && next.opcode == Opcode.MOVE_RESULT_OBJECT) {
-                        method.replaceInstruction(
+                        mutableMethod.replaceInstruction(
                             index,
                             "const-string v${next.registerA}, \"${escapeSmali(value)}\"",
                         )
-                        method.replaceInstruction(index + 1, "nop")
+                        mutableMethod.replaceInstruction(index + 1, "nop")
                         patched++
                     }
                 }

--- a/patches/src/main/kotlin/patches/universal/misc/SpoofCpuArchitecturePatch.kt
+++ b/patches/src/main/kotlin/patches/universal/misc/SpoofCpuArchitecturePatch.kt
@@ -7,6 +7,7 @@ import com.android.tools.smali.dexlib2.Opcode
 import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
 import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
 import com.android.tools.smali.dexlib2.iface.reference.FieldReference
+import patches.universal.ads.util.findMutableMethodOf
 import java.util.logging.Logger
 
 private const val BUILD_CLASS = "Landroid/os/Build;"
@@ -47,8 +48,9 @@ val spoofCpuArchitecturePatch = bytecodePatch(
 
         var patched = 0
         classDefForEach { classDef ->
-            val mutableClass = mutableClassDefBy(classDef)
-            for (method in mutableClass.methods) {
+            val mutableClass by lazy { mutableClassDefBy(classDef) }
+            for (method in classDef.methods) {
+                val mutableMethod by lazy { mutableClass.findMutableMethodOf(method) }
                 val implementation = method.implementation ?: continue
                 val instructions = implementation.instructions.toList()
                 for ((index, instruction) in instructions.withIndex()) {
@@ -60,11 +62,11 @@ val spoofCpuArchitecturePatch = bytecodePatch(
 
                     val next = instructions.getOrNull(index + 1) as? OneRegisterInstruction
                     if (next != null && next.opcode == Opcode.MOVE_RESULT_OBJECT) {
-                        method.replaceInstruction(
+                        mutableMethod.replaceInstruction(
                             index,
                             "const-string v${next.registerA}, \"${escapeSmali(value)}\"",
                         )
-                        method.replaceInstruction(index + 1, "nop")
+                        mutableMethod.replaceInstruction(index + 1, "nop")
                         patched++
                     }
                 }

--- a/patches/src/main/kotlin/patches/universal/misc/SpoofDeveloperOptionsPatch.kt
+++ b/patches/src/main/kotlin/patches/universal/misc/SpoofDeveloperOptionsPatch.kt
@@ -3,9 +3,6 @@ package patches.universal.misc
 import app.morphe.patcher.extensions.InstructionExtensions.replaceInstruction
 import app.morphe.patcher.patch.BytecodePatchContext
 import app.morphe.patcher.patch.bytecodePatch
-import app.morphe.patcher.patch.resourcePatch
-import patches.universal.manifest.NS_ANDROID
-import patches.universal.manifest.applicationOrNull
 import com.android.tools.smali.dexlib2.Opcode
 import com.android.tools.smali.dexlib2.builder.instruction.BuilderInstruction35c
 import com.android.tools.smali.dexlib2.builder.instruction.BuilderInstruction3rc
@@ -15,6 +12,10 @@ import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
 import com.android.tools.smali.dexlib2.iface.reference.FieldReference
 import com.android.tools.smali.dexlib2.iface.reference.MethodReference
 import com.android.tools.smali.dexlib2.iface.reference.StringReference
+import app.morphe.patcher.util.proxy.mutableTypes.MutableClass
+import patches.universal.ads.util.findMutableMethodOf
+import patches.universal.manifest.NS_ANDROID
+import patches.universal.manifest.applicationOrNull
 import java.util.logging.Logger
 
 /**
@@ -55,8 +56,9 @@ internal fun BytecodePatchContext.foldSettingsGetters(
 ): Int {
     var patched = 0
     classDefForEach { classDef ->
-        val mutableClass = mutableClassDefBy(classDef)
-        for (method in mutableClass.methods) {
+        val mutableClass by lazy { mutableClassDefBy(classDef) }
+        for (method in classDef.methods) {
+            val mutableMethod by lazy { mutableClass.findMutableMethodOf(method) }
             val implementation = method.implementation ?: continue
             // Snapshot; one-for-one replacements keep indices valid.
             val instructions: List<Instruction> = implementation.instructions.toList()
@@ -120,10 +122,10 @@ internal fun BytecodePatchContext.foldSettingsGetters(
                     } else {
                         "const-string v$resultRegister, \"\""
                     }
-                    method.replaceInstruction(index, replacement)
-                    method.replaceInstruction(index + 1, "nop")
+                    mutableMethod.replaceInstruction(index, replacement)
+                    mutableMethod.replaceInstruction(index + 1, "nop")
                 } else {
-                    method.replaceInstruction(index, "nop")
+                    mutableMethod.replaceInstruction(index, "nop")
                 }
                 patched++
             }

--- a/patches/src/main/kotlin/patches/universal/misc/SpoofDeviceModelPatch.kt
+++ b/patches/src/main/kotlin/patches/universal/misc/SpoofDeviceModelPatch.kt
@@ -7,6 +7,7 @@ import com.android.tools.smali.dexlib2.Opcode
 import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
 import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
 import com.android.tools.smali.dexlib2.iface.reference.FieldReference
+import patches.universal.ads.util.findMutableMethodOf
 import java.util.logging.Logger
 
 private const val BUILD_CLASS = "Landroid/os/Build;"
@@ -58,8 +59,9 @@ val spoofDeviceModelPatch = bytecodePatch(
 
         var patched = 0
         classDefForEach { classDef ->
-            val mutableClass = mutableClassDefBy(classDef)
-            for (method in mutableClass.methods) {
+            val mutableClass by lazy { mutableClassDefBy(classDef) }
+            for (method in classDef.methods) {
+                val mutableMethod by lazy { mutableClass.findMutableMethodOf(method) }
                 val implementation = method.implementation ?: continue
                 // Snapshot; one-for-one replacements keep indices valid.
                 val instructions = implementation.instructions.toList()
@@ -71,11 +73,11 @@ val spoofDeviceModelPatch = bytecodePatch(
 
                     val next = instructions.getOrNull(index + 1) as? OneRegisterInstruction
                     if (next != null && next.opcode == Opcode.MOVE_RESULT_OBJECT) {
-                        method.replaceInstruction(
+                        mutableMethod.replaceInstruction(
                             index,
                             "const-string v${next.registerA}, \"${escapeSmali(replacements[field.name]!!)}\"",
                         )
-                        method.replaceInstruction(index + 1, "nop")
+                        mutableMethod.replaceInstruction(index + 1, "nop")
                         patched++
                     }
                 }

--- a/patches/src/main/kotlin/patches/universal/misc/SpoofFixedLocationPatch.kt
+++ b/patches/src/main/kotlin/patches/universal/misc/SpoofFixedLocationPatch.kt
@@ -7,6 +7,7 @@ import com.android.tools.smali.dexlib2.Opcode
 import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
 import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
 import com.android.tools.smali.dexlib2.iface.reference.MethodReference
+import patches.universal.ads.util.findMutableMethodOf
 import java.util.logging.Logger
 
 @Suppress("unused")
@@ -48,8 +49,9 @@ val spoofFixedLocationPatch = bytecodePatch(
 
         var patched = 0
         classDefForEach { classDef ->
-            val mutableClass = mutableClassDefBy(classDef)
-            for (method in mutableClass.methods) {
+            val mutableClass by lazy { mutableClassDefBy(classDef) }
+            for (method in classDef.methods) {
+                val mutableMethod by lazy { mutableClass.findMutableMethodOf(method) }
                 val impl = method.implementation ?: continue
                 val instructions = impl.instructions.toList()
                 for ((index, insn) in instructions.withIndex()) {
@@ -116,8 +118,9 @@ val spoofFixedLocationPatch = bytecodePatch(
         // Proper patch for LocationManager.getLastKnownLocation
         var lmPatched = 0
         classDefForEach { classDef ->
-            val mutableClass = mutableClassDefBy(classDef)
-            for (method in mutableClass.methods) {
+            val mutableClass by lazy { mutableClassDefBy(classDef) }
+            for (method in classDef.methods) {
+                val mutableMethod by lazy { mutableClass.findMutableMethodOf(method) }
                 val impl = method.implementation ?: continue
                 val instructions = impl.instructions.toList()
                 for ((index, insn) in instructions.withIndex()) {
@@ -133,10 +136,10 @@ val spoofFixedLocationPatch = bytecodePatch(
                     // Note: This assumes res+1 and res+2 are available (they are, as they are temp registers in the method's register window)
                     val latHex = java.lang.Long.toHexString(latBits)
                     val lonHex = java.lang.Long.toHexString(lonBits)
-                    method.replaceInstruction(index, "new-instance v$res, Landroid/location/Location;")
+                    mutableMethod.replaceInstruction(index, "new-instance v$res, Landroid/location/Location;")
                     // Need to handle the invoke + move-result pair as three instructions, so we need to add extra
                     // For simplicity, use addInstructions to inject after
-                    method.replaceInstruction(index + 1, """
+                    mutableMethod.replaceInstruction(index + 1, """
                         const-string v${res + 1}, "gps"
                         invoke-direct {v$res, v${res + 1}}, Landroid/location/Location;-><init>(Ljava/lang/String;)V
                         const-wide v${res + 1}, 0x$latHex
@@ -151,8 +154,9 @@ val spoofFixedLocationPatch = bytecodePatch(
 
         var fusedPatched = 0
         classDefForEach { classDef ->
-            val mutableClass = mutableClassDefBy(classDef)
-            for (method in mutableClass.methods) {
+            val mutableClass by lazy { mutableClassDefBy(classDef) }
+            for (method in classDef.methods) {
+                val mutableMethod by lazy { mutableClass.findMutableMethodOf(method) }
                 val impl = method.implementation ?: continue
                 val instructions = impl.instructions.toList()
                 for ((index, insn) in instructions.withIndex()) {
@@ -167,8 +171,8 @@ val spoofFixedLocationPatch = bytecodePatch(
                     val latHex = java.lang.Long.toHexString(latBits)
                     val lonHex = java.lang.Long.toHexString(lonBits)
                     // Create Location then wrap in Tasks.forResult
-                    method.replaceInstruction(index, "new-instance v$res, Landroid/location/Location;")
-                    method.replaceInstruction(index + 1, """
+                    mutableMethod.replaceInstruction(index, "new-instance v$res, Landroid/location/Location;")
+                    mutableMethod.replaceInstruction(index + 1, """
                         const-string v${res + 1}, "gps"
                         invoke-direct {v$res, v${res + 1}}, Landroid/location/Location;-><init>(Ljava/lang/String;)V
                         const-wide v${res + 1}, 0x$latHex

--- a/patches/src/main/kotlin/patches/universal/misc/SpoofSdkLevelPatch.kt
+++ b/patches/src/main/kotlin/patches/universal/misc/SpoofSdkLevelPatch.kt
@@ -7,6 +7,7 @@ import com.android.tools.smali.dexlib2.Opcode
 import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
 import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
 import com.android.tools.smali.dexlib2.iface.reference.FieldReference
+import patches.universal.ads.util.findMutableMethodOf
 import java.util.logging.Logger
 
 private const val VERSION_CLASS = "Landroid/os/Build\$VERSION;"
@@ -39,8 +40,9 @@ val spoofSdkLevelPatch = bytecodePatch(
 
         var patched = 0
         classDefForEach { classDef ->
-            val mutableClass = mutableClassDefBy(classDef)
-            for (method in mutableClass.methods) {
+            val mutableClass by lazy { mutableClassDefBy(classDef) }
+            for (method in classDef.methods) {
+                val mutableMethod by lazy { mutableClass.findMutableMethodOf(method) }
                 val implementation = method.implementation ?: continue
                 val instructions = implementation.instructions.toList()
                 for ((index, instruction) in instructions.withIndex()) {
@@ -51,11 +53,11 @@ val spoofSdkLevelPatch = bytecodePatch(
 
                     val next = instructions.getOrNull(index + 1) as? OneRegisterInstruction
                     if (next != null && next.opcode == Opcode.MOVE_RESULT) {
-                        method.replaceInstruction(
+                        mutableMethod.replaceInstruction(
                             index,
                             "const/4 v${next.registerA}, 0x${value.toString(16)}",
                         )
-                        method.replaceInstruction(index + 1, "nop")
+                        mutableMethod.replaceInstruction(index + 1, "nop")
                         patched++
                     }
                 }

--- a/patches/src/main/kotlin/patches/universal/misc/SpoofSignatureMatchPatch.kt
+++ b/patches/src/main/kotlin/patches/universal/misc/SpoofSignatureMatchPatch.kt
@@ -6,6 +6,7 @@ import com.android.tools.smali.dexlib2.Opcode
 import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
 import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
 import com.android.tools.smali.dexlib2.iface.reference.MethodReference
+import patches.universal.ads.util.findMutableMethodOf
 import java.util.logging.Logger
 
 @Suppress("unused")
@@ -21,8 +22,9 @@ val spoofSignatureMatchPatch = bytecodePatch(
 
         var patched = 0
         classDefForEach { classDef ->
-            val mutableClass = mutableClassDefBy(classDef)
-            for (method in mutableClass.methods) {
+            val mutableClass by lazy { mutableClassDefBy(classDef) }
+            for (method in classDef.methods) {
+                val mutableMethod by lazy { mutableClass.findMutableMethodOf(method) }
                 val implementation = method.implementation ?: continue
                 // Snapshot; one-for-one replacements keep indices valid.
                 val instructions = implementation.instructions.toList()
@@ -41,10 +43,10 @@ val spoofSignatureMatchPatch = bytecodePatch(
                     // SIGNATURE_MATCH == 0.
                     val next = instructions.getOrNull(index + 1) as? OneRegisterInstruction
                     if (next != null && next.opcode == Opcode.MOVE_RESULT) {
-                        method.replaceInstruction(index, "const/4 v${next.registerA}, 0x0")
-                        method.replaceInstruction(index + 1, "nop")
+                        mutableMethod.replaceInstruction(index, "const/4 v${next.registerA}, 0x0")
+                        mutableMethod.replaceInstruction(index + 1, "nop")
                     } else {
-                        method.replaceInstruction(index, "nop")
+                        mutableMethod.replaceInstruction(index, "nop")
                     }
                     patched++
                 }

--- a/patches/src/main/kotlin/patches/universal/misc/StripBuildConfigDebugPatch.kt
+++ b/patches/src/main/kotlin/patches/universal/misc/StripBuildConfigDebugPatch.kt
@@ -7,6 +7,7 @@ import com.android.tools.smali.dexlib2.Opcode
 import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
 import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
 import com.android.tools.smali.dexlib2.iface.reference.FieldReference
+import patches.universal.ads.util.findMutableMethodOf
 import java.util.logging.Logger
 
 @Suppress("unused")
@@ -27,8 +28,9 @@ val stripBuildConfigDebugPatch = bytecodePatch(
         val target = if (forceDebug == true) "0x1" else "0x0"
         var patched = 0
         classDefForEach { classDef ->
-            val mutableClass = mutableClassDefBy(classDef)
-            for (method in mutableClass.methods) {
+            val mutableClass by lazy { mutableClassDefBy(classDef) }
+            for (method in classDef.methods) {
+                val mutableMethod by lazy { mutableClass.findMutableMethodOf(method) }
                 val impl = method.implementation ?: continue
                 val instructions = impl.instructions.toList()
                 for ((index, insn) in instructions.withIndex()) {
@@ -39,7 +41,7 @@ val stripBuildConfigDebugPatch = bytecodePatch(
                     if (!ref.definingClass.endsWith("BuildConfig;")) continue
                     val reg = (insn as? OneRegisterInstruction)?.registerA ?: continue
                     val constInstr = if (reg <= 0xf) "const/4 v$reg, $target" else "const/16 v$reg, $target"
-                    method.replaceInstruction(index, constInstr)
+                    mutableMethod.replaceInstruction(index, constInstr)
                     patched++
                 }
             }

--- a/patches/src/main/kotlin/patches/universal/misc/StripPackageVerifierPatch.kt
+++ b/patches/src/main/kotlin/patches/universal/misc/StripPackageVerifierPatch.kt
@@ -11,6 +11,7 @@ import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
 import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
 import com.android.tools.smali.dexlib2.iface.reference.MethodReference
 import com.android.tools.smali.dexlib2.iface.reference.StringReference
+import patches.universal.ads.util.findMutableMethodOf
 import java.util.logging.Logger
 
 @Suppress("unused")
@@ -31,8 +32,9 @@ val stripPackageVerifierPatch = bytecodePatch(
         val target = if (disabled == true) 0 else 1
         var patched = 0
         classDefForEach { classDef ->
-            val mutableClass = mutableClassDefBy(classDef)
-            for (method in mutableClass.methods) {
+            val mutableClass by lazy { mutableClassDefBy(classDef) }
+            for (method in classDef.methods) {
+                val mutableMethod by lazy { mutableClass.findMutableMethodOf(method) }
                 val impl = method.implementation ?: continue
                 val instructions: List<Instruction> = impl.instructions.toList()
                 for ((index, insn) in instructions.withIndex()) {
@@ -62,8 +64,8 @@ val stripPackageVerifierPatch = bytecodePatch(
                     val next = instructions.getOrNull(index + 1)
                     if (next != null && next.opcode == Opcode.MOVE_RESULT) {
                         val resultRegister = (next as OneRegisterInstruction).registerA
-                        method.replaceInstruction(index, "const/4 v$resultRegister, $target")
-                        method.replaceInstruction(index + 1, "nop")
+                        mutableMethod.replaceInstruction(index, "const/4 v$resultRegister, $target")
+                        mutableMethod.replaceInstruction(index + 1, "nop")
                         patched++
                     }
                 }

--- a/patches/src/main/kotlin/patches/universal/misc/TrustUserCertificatesPatch.kt
+++ b/patches/src/main/kotlin/patches/universal/misc/TrustUserCertificatesPatch.kt
@@ -2,6 +2,7 @@ package patches.universal.misc
 
 import app.morphe.patcher.extensions.InstructionExtensions.addInstruction
 import app.morphe.patcher.patch.bytecodePatch
+import patches.universal.ads.util.findMutableMethodOf
 import java.util.logging.Logger
 
 private const val TRUST_MANAGER = "Ljavax/net/ssl/X509TrustManager;"
@@ -25,14 +26,14 @@ val trustUserCertificatesPatch = bytecodePatch(
             // Only classes that directly implement the trust manager interface.
             if (classDef.interfaces.none { it == TRUST_MANAGER }) return@classDefForEach
 
-            val mutableClass = mutableClassDefBy(classDef)
+            val mutableClass by lazy { mutableClassDefBy(classDef) }
             var changed = false
-            for (method in mutableClass.methods) {
+            for (method in classDef.methods) {
                 // Both check methods are void; an immediate return accepts every chain.
                 if (method.returnType != "V") continue
                 if (method.name !in checkMethods) continue
 
-                method.addInstruction(0, "return-void")
+                mutableClass.findMutableMethodOf(method).addInstruction(0, "return-void")
                 changed = true
                 patchedMethods++
             }

--- a/patches/src/main/kotlin/patches/universal/misc/UnlockNotificationChannelsPatch.kt
+++ b/patches/src/main/kotlin/patches/universal/misc/UnlockNotificationChannelsPatch.kt
@@ -6,6 +6,7 @@ import com.android.tools.smali.dexlib2.Opcode
 import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
 import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
 import com.android.tools.smali.dexlib2.iface.reference.MethodReference
+import patches.universal.ads.util.findMutableMethodOf
 import java.util.logging.Logger
 
 @Suppress("unused")
@@ -21,8 +22,9 @@ val unlockNotificationChannelsPatch = bytecodePatch(
         // Merged to 1 scan to fix #59 Truecaller 1024 MB OOM.
         var patched = 0
         classDefForEach { classDef ->
-            val mutableClass = mutableClassDefBy(classDef)
-            for (method in mutableClass.methods) {
+            val mutableClass by lazy { mutableClassDefBy(classDef) }
+            for (method in classDef.methods) {
+                val mutableMethod by lazy { mutableClass.findMutableMethodOf(method) }
                 val impl = method.implementation ?: continue
                 val instructions = impl.instructions.toList()
                 for ((index, insn) in instructions.withIndex()) {
@@ -36,10 +38,10 @@ val unlockNotificationChannelsPatch = bytecodePatch(
                     }
                     val next = instructions.getOrNull(index + 1) as? OneRegisterInstruction
                     if (next != null && next.opcode == Opcode.MOVE_RESULT) {
-                        method.replaceInstruction(index, "const/4 v${next.registerA}, $value")
-                        method.replaceInstruction(index + 1, "nop")
+                        mutableMethod.replaceInstruction(index, "const/4 v${next.registerA}, $value")
+                        mutableMethod.replaceInstruction(index + 1, "nop")
                     } else {
-                        method.replaceInstruction(index, "nop")
+                        mutableMethod.replaceInstruction(index, "nop")
                     }
                     patched++
                 }

--- a/patches/src/main/kotlin/patches/universal/network/DisableForcedOnlineChecksPatch.kt
+++ b/patches/src/main/kotlin/patches/universal/network/DisableForcedOnlineChecksPatch.kt
@@ -6,6 +6,7 @@ import app.morphe.patcher.patch.bytecodePatch
 import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
 import com.android.tools.smali.dexlib2.iface.reference.StringReference
 import java.util.Locale
+import patches.universal.ads.util.findMutableMethodOf
 import java.util.logging.Logger
 import patches.universal.misc.foldBooleanReturns
 
@@ -147,8 +148,9 @@ val disableForcedOnlineChecksPatch = bytecodePatch(
             classDefForEach { classDef ->
                 if (!useGeneric && !detectedSelectedEngine) return@classDefForEach
 
-                val mutableClass = mutableClassDefBy(classDef)
-                for (method in mutableClass.methods) {
+                val mutableClass by lazy { mutableClassDefBy(classDef) }
+                for (method in classDef.methods) {
+                    val mutableMethod by lazy { mutableClass.findMutableMethodOf(method) }
                     if (method.returnType != "Z") continue
                     val implementation = method.implementation ?: continue
                     val methodName = method.name.normalized()
@@ -163,7 +165,7 @@ val disableForcedOnlineChecksPatch = bytecodePatch(
                     if (implementation.registerCount < 1) continue
 
                     val value = if (positive) "0x1" else "0x0"
-                    method.addInstructions(0, "const/4 v0, $value\nreturn v0")
+                    mutableMethod.addInstructions(0, "const/4 v0, $value\nreturn v0")
                     patched++
                 }
             }

--- a/patches/src/main/kotlin/patches/universal/privacy/BlockScreenshotDetectionPatch.kt
+++ b/patches/src/main/kotlin/patches/universal/privacy/BlockScreenshotDetectionPatch.kt
@@ -3,6 +3,7 @@ package patches.universal.privacy
 import app.morphe.patcher.extensions.InstructionExtensions.addInstructions
 import app.morphe.patcher.patch.bytecodePatch
 import patches.universal.ads.util.cloneMutable
+import patches.universal.ads.util.findMutableMethodOf
 import patches.universal.ads.util.p0Register
 import java.util.logging.Logger
 
@@ -23,15 +24,16 @@ val blockScreenshotDetectionPatch = bytecodePatch(
         classDefForEach { classDef ->
             if (classDef.superclass?.endsWith("Activity;") != true) return@classDefForEach
 
-            val mutableClass = mutableClassDefBy(classDef)
-            val onCreate = mutableClass.methods.firstOrNull {
+            val mutableClass by lazy { mutableClassDefBy(classDef) }
+            val onCreate = classDef.methods.firstOrNull {
                 it.name == "onCreate" && it.returnType == "V" &&
                     it.parameterTypes == listOf("Landroid/os/Bundle;")
             } ?: return@classDefForEach
 
+            val mutableOnCreate = mutableClass.findMutableMethodOf(onCreate)
             val contextReg = onCreate.p0Register
             val b = onCreate.implementation!!.registerCount
-            val cloned = onCreate.cloneMutable(additionalRegisters = 3)
+            val cloned = mutableOnCreate.cloneMutable(additionalRegisters = 3)
 
             cloned.addInstructions(
                 0,
@@ -43,7 +45,7 @@ val blockScreenshotDetectionPatch = bytecodePatch(
                 """.trimIndent(),
             )
 
-            mutableClass.methods.remove(onCreate)
+            mutableClass.methods.remove(mutableOnCreate)
             mutableClass.methods.add(cloned)
             patchedActivities++
         }

--- a/patches/src/main/kotlin/patches/universal/privacy/HideCurrentLocationPatch.kt
+++ b/patches/src/main/kotlin/patches/universal/privacy/HideCurrentLocationPatch.kt
@@ -4,6 +4,7 @@ import app.morphe.patcher.extensions.InstructionExtensions.replaceInstruction
 import app.morphe.patcher.patch.bytecodePatch
 import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
 import com.android.tools.smali.dexlib2.iface.reference.MethodReference
+import patches.universal.ads.util.findMutableMethodOf
 import java.util.logging.Logger
 
 @Suppress("unused")
@@ -16,15 +17,16 @@ val hideCurrentLocationPatch = bytecodePatch(
         val logger = Logger.getLogger(this::class.java.name)
         var patched = 0
         classDefForEach { classDef ->
-            val mutableClass = mutableClassDefBy(classDef)
-            for (method in mutableClass.methods) {
+            val mutableClass by lazy { mutableClassDefBy(classDef) }
+            for (method in classDef.methods) {
+                val mutableMethod by lazy { mutableClass.findMutableMethodOf(method) }
                 val impl = method.implementation ?: continue
                 val instructions = impl.instructions.toList()
                 for ((index, insn) in instructions.withIndex()) {
                     val ref = (insn as? ReferenceInstruction)?.reference as? MethodReference ?: continue
                     if (ref.definingClass != "Landroid/location/LocationManager;" && ref.definingClass != "Lcom/google/android/gms/location/FusedLocationProviderClient;") continue
                     if (ref.name != "getCurrentLocation") continue
-                    method.replaceInstruction(index, "nop")
+                    mutableMethod.replaceInstruction(index, "nop")
                     patched++
                 }
             }

--- a/patches/src/main/kotlin/patches/universal/privacy/ReportNoCamerasPatch.kt
+++ b/patches/src/main/kotlin/patches/universal/privacy/ReportNoCamerasPatch.kt
@@ -8,6 +8,7 @@ import com.android.tools.smali.dexlib2.iface.instruction.Instruction
 import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
 import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
 import com.android.tools.smali.dexlib2.iface.reference.MethodReference
+import patches.universal.ads.util.findMutableMethodOf
 import java.util.logging.Logger
 
 @Suppress("unused")
@@ -44,8 +45,9 @@ val reportNoCamerasPatch = bytecodePatch(
                 if (hasRef) break
             }
             if (!hasRef) return@classDefForEach
-            val mutableClass = mutableClassDefBy(classDef)
-            for (method in mutableClass.methods) {
+            val mutableClass by lazy { mutableClassDefBy(classDef) }
+            for (method in classDef.methods) {
+                val mutableMethod by lazy { mutableClass.findMutableMethodOf(method) }
                 val implementation = method.implementation ?: continue
                 val instructions: List<Instruction> = implementation.instructions.toList()
                 for ((index, instruction) in instructions.withIndex()) {
@@ -59,8 +61,8 @@ val reportNoCamerasPatch = bytecodePatch(
                     val next = instructions.getOrNull(index + 1)
                     if (next != null && next.opcode == Opcode.MOVE_RESULT_OBJECT) {
                         val resultRegister = (next as OneRegisterInstruction).registerA
-                        method.replaceInstruction(index, "const/4 v$resultRegister, 0x0")
-                        method.replaceInstruction(index + 1, "new-array v$resultRegister, v$resultRegister, [Ljava/lang/String;")
+                        mutableMethod.replaceInstruction(index, "const/4 v$resultRegister, 0x0")
+                        mutableMethod.replaceInstruction(index + 1, "new-array v$resultRegister, v$resultRegister, [Ljava/lang/String;")
                         patched++
                     }
                 }

--- a/patches/src/main/kotlin/patches/universal/resolution/TabletModePatch.kt
+++ b/patches/src/main/kotlin/patches/universal/resolution/TabletModePatch.kt
@@ -8,6 +8,7 @@ import com.android.tools.smali.dexlib2.iface.instruction.Instruction
 import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
 import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
 import com.android.tools.smali.dexlib2.iface.reference.FieldReference
+import patches.universal.ads.util.findMutableMethodOf
 import java.util.logging.Logger
 
 @Suppress("unused")
@@ -42,8 +43,9 @@ val tabletModePatch = bytecodePatch(
                 if (hasRef) break
             }
             if (!hasRef) return@classDefForEach
-            val mutableClass = mutableClassDefBy(classDef)
-            for (method in mutableClass.methods) {
+            val mutableClass by lazy { mutableClassDefBy(classDef) }
+            for (method in classDef.methods) {
+                val mutableMethod by lazy { mutableClass.findMutableMethodOf(method) }
                 val implementation = method.implementation ?: continue
                 val instructions: List<Instruction> = implementation.instructions.toList()
                 for ((index, instruction) in instructions.withIndex()) {
@@ -56,7 +58,7 @@ val tabletModePatch = bytecodePatch(
                     if (reference.type != "I") continue
 
                     val register = (instruction as? OneRegisterInstruction)?.registerA ?: continue
-                    method.replaceInstruction(index, "const/16 v$register, 0x${width.toString(16)}")
+                    mutableMethod.replaceInstruction(index, "const/16 v$register, 0x${width.toString(16)}")
                     patched++
                 }
             }

--- a/patches/src/main/kotlin/patches/universal/telemetry/DisableCrashReportersPatch.kt
+++ b/patches/src/main/kotlin/patches/universal/telemetry/DisableCrashReportersPatch.kt
@@ -4,6 +4,7 @@ import app.morphe.patcher.extensions.InstructionExtensions.addInstruction
 import app.morphe.patcher.patch.booleanOption
 import app.morphe.patcher.patch.bytecodePatch
 import com.android.tools.smali.dexlib2.AccessFlags
+import patches.universal.ads.util.findMutableMethodOf
 import java.util.logging.Logger
 
 /** Class prefixes of the supported crash-reporting SDKs. */
@@ -39,15 +40,15 @@ val disableCrashReportersPatch = bytecodePatch(
             val sdkName = crashSdkPrefixes.entries.firstOrNull { classDef.type.startsWith(it.key) }?.value
                 ?: return@classDefForEach
 
-            val mutableClass = mutableClassDefBy(classDef)
-            for (method in mutableClass.methods) {
+            val mutableClass by lazy { mutableClassDefBy(classDef) }
+            for (method in classDef.methods) {
                 // Only static void bootstrap methods are touched: constructors and
                 // value-returning methods are never modified.
                 if (method.returnType != "V") continue
                 if (!AccessFlags.STATIC.isSet(method.accessFlags)) continue
                 if (method.name !in entryPointNames) continue
 
-                method.addInstruction(0, "return-void")
+                mutableClass.findMutableMethodOf(method).addInstruction(0, "return-void")
                 detected[sdkName] = (detected[sdkName] ?: 0) + 1
                 patched++
             }

--- a/patches/src/main/kotlin/patches/universal/telemetry/DisableTelemetryPatch.kt
+++ b/patches/src/main/kotlin/patches/universal/telemetry/DisableTelemetryPatch.kt
@@ -4,6 +4,7 @@ import app.morphe.patcher.extensions.InstructionExtensions.addInstruction
 import app.morphe.patcher.extensions.InstructionExtensions.addInstructions
 import app.morphe.patcher.patch.booleanOption
 import app.morphe.patcher.patch.bytecodePatch
+import patches.universal.ads.util.findMutableMethodOf
 import java.util.logging.Logger
 
 private fun app.morphe.patcher.patch.BytecodePatchContext.safeEarlyReturn(fingerprint: app.morphe.patcher.Fingerprint): Boolean {
@@ -189,17 +190,19 @@ val disableTelemetryPatch = bytecodePatch(
                 val tl = classDef.type.lowercase()
                 if (!tl.contains("analytics") && !tl.contains("tracker") && !tl.contains("telemetry") && !tl.contains("event") && !tl.contains("metric")) return@classDefForEach
                 if (tl.contains("okhttp") || tl.contains("androidx") || tl.contains("com/google/android/gms")) return@classDefForEach
-                val mutableClass = try { mutableClassDefBy(classDef) } catch (_: Exception) { return@classDefForEach }
-                for (method in mutableClass.methods) {
+                val mutableClass by lazy { try { mutableClassDefBy(classDef) } catch (_: Exception) { null } }
+                for (method in classDef.methods) {
                     val n = method.name.lowercase()
                     if (!n.contains("logevent") && !n.contains("track") && !n.contains("send") && !n.contains("analytics")) continue
                     if (method.implementation == null) continue
+                    val mc = mutableClass ?: continue
+                    val mutableMethod = mc.findMutableMethodOf(method)
                     try {
                         val ret = method.returnType
                         when {
-                            ret == "V" -> method.addInstructions(0, "return-void")
-                            ret.startsWith("L") || ret.startsWith("[") -> method.addInstructions(0, "const/4 v0, 0x0\nreturn-object v0")
-                            else -> method.addInstructions(0, "const/4 v0, 0x0\nreturn v0")
+                            ret == "V" -> mutableMethod.addInstructions(0, "return-void")
+                            ret.startsWith("L") || ret.startsWith("[") -> mutableMethod.addInstructions(0, "const/4 v0, 0x0\nreturn-object v0")
+                            else -> mutableMethod.addInstructions(0, "const/4 v0, 0x0\nreturn v0")
                         }
                         genericPatched++
                     } catch (_: Exception) {}

--- a/patches/src/main/kotlin/patches/universal/ui/CustomStartupDialogPatch.kt
+++ b/patches/src/main/kotlin/patches/universal/ui/CustomStartupDialogPatch.kt
@@ -10,6 +10,7 @@ import com.android.tools.smali.dexlib2.AccessFlags
 import com.android.tools.smali.dexlib2.immutable.ImmutableField
 import app.morphe.patcher.util.proxy.mutableTypes.MutableField.Companion.toMutable
 import patches.universal.ads.util.cloneMutable
+import patches.universal.ads.util.findMutableMethodOf
 import patches.universal.ads.util.p0Register
 import java.util.logging.Logger
 
@@ -100,12 +101,13 @@ val customStartupDialogPatch = bytecodePatch(
         val candidates = mutableListOf<Pair<MutableClass, MutableMethod>>()
         classDefForEach { classDef ->
             if (!isActivity(classDef.type)) return@classDefForEach
-            val mutableClass = mutableClassDefBy(classDef)
-            val onCreate = mutableClass.methods.firstOrNull {
+            val onCreate = classDef.methods.firstOrNull {
                 it.name == "onCreate" && it.returnType == "V" &&
                     it.parameterTypes == listOf("Landroid/os/Bundle;")
             } ?: return@classDefForEach
-            candidates.add(mutableClass to onCreate)
+            val mutableClass = mutableClassDefBy(classDef)
+            val mutableOnCreate = mutableClass.findMutableMethodOf(onCreate)
+            candidates.add(mutableClass to mutableOnCreate)
         }
 
         // Skip the launcher activity only when the app has more than one

--- a/patches/src/main/kotlin/patches/universal/ui/CustomStartupSoundPatch.kt
+++ b/patches/src/main/kotlin/patches/universal/ui/CustomStartupSoundPatch.kt
@@ -129,16 +129,7 @@ val customStartupSoundPatch = bytecodePatch(
             if (cls != null && m != null) cls to m else null
         } else null
 
-        val (mutableClass, onCreate) = appAndMethod ?: run {
-            var result: Pair<MutableClass, MutableMethod>? = null
-            classDefForEach { classDef ->
-                if (classDef.superclass != "Landroid/app/Application;") return@classDefForEach
-                val mc = mutableClassDefBy(classDef)
-                val m = mc.methods.firstOrNull { it.name == "onCreate" && it.returnType == "V" && it.parameterTypes.isEmpty() }
-                if (m != null && result == null) result = mc to m
-            }
-            result
-        } ?: run {
+        val (mutableClass, onCreate) = appAndMethod ?: findApplicationOnCreate() ?: run {
             logger.warning("No Application.onCreate found. No changes applied.")
             return@execute
         }

--- a/patches/src/main/kotlin/patches/universal/ui/CustomStartupToastPatch.kt
+++ b/patches/src/main/kotlin/patches/universal/ui/CustomStartupToastPatch.kt
@@ -7,6 +7,7 @@ import app.morphe.patcher.patch.stringOption
 import app.morphe.patcher.util.proxy.mutableTypes.MutableClass
 import app.morphe.patcher.util.proxy.mutableTypes.MutableMethod
 import patches.universal.ads.util.cloneMutable
+import patches.universal.ads.util.findMutableMethodOf
 import patches.universal.ads.util.p0Register
 import java.util.logging.Logger
 
@@ -19,12 +20,14 @@ internal fun BytecodePatchContext.findApplicationOnCreate(): Pair<MutableClass, 
     var result: Pair<MutableClass, MutableMethod>? = null
     classDefForEach { classDef ->
         if (classDef.superclass != "Landroid/app/Application;") return@classDefForEach
-        val mutableClass = mutableClassDefBy(classDef)
-        val onCreate = mutableClass.methods.firstOrNull {
+        val onCreate = classDef.methods.firstOrNull {
             it.name == "onCreate" && it.returnType == "V" && it.parameterTypes.isEmpty()
         } ?: return@classDefForEach
         // Keep the first hit; later Application subclasses are ignored.
-        if (result == null) result = mutableClass to onCreate
+        if (result == null) {
+            val mutableClass = mutableClassDefBy(classDef)
+            result = mutableClass to mutableClass.findMutableMethodOf(onCreate)
+        }
     }
     return result
 }

--- a/patches/src/main/kotlin/patches/universal/universaloverlay/UniversalOverlayPatch.kt
+++ b/patches/src/main/kotlin/patches/universal/universaloverlay/UniversalOverlayPatch.kt
@@ -599,9 +599,8 @@ private fun app.morphe.patcher.patch.BytecodePatchContext.findFallbackActivity()
     val candidates = mutableListOf<MutableClass>()
     classDefForEach { classDef ->
         if (!isActivity(classDef.type)) return@classDefForEach
-        val candidate = mutableClassDefBy(classDef)
-        if (candidate.methods.any { it.name == "onCreate" && it.returnType == "V" && it.parameterTypes == listOf("Landroid/os/Bundle;") }) {
-            candidates += candidate
+        if (classDef.methods.any { it.name == "onCreate" && it.returnType == "V" && it.parameterTypes == listOf("Landroid/os/Bundle;") }) {
+            candidates += mutableClassDefBy(classDef)
         }
     }
     return candidates.firstOrNull { it.type == override } ?: candidates.firstOrNull()

--- a/patches/src/main/kotlin/patches/universal/unlock/UnlimitedCurrenciesPatch.kt
+++ b/patches/src/main/kotlin/patches/universal/unlock/UnlimitedCurrenciesPatch.kt
@@ -15,6 +15,7 @@ import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
 import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
 import com.android.tools.smali.dexlib2.iface.reference.MethodReference
 import com.android.tools.smali.dexlib2.iface.reference.StringReference
+import patches.universal.ads.util.findMutableMethodOf
 import java.util.logging.Logger
 
 private val currencySubstrings = listOf(
@@ -201,8 +202,9 @@ val unlimitedCurrenciesPatch = bytecodePatch(
             }
             if (!foundPrefsCall) return@classDefForEach
 
-            val mutableClass = mutableClassDefBy(classDef)
-            for (method in mutableClass.methods) {
+            val mutableClass by lazy { mutableClassDefBy(classDef) }
+            for (method in classDef.methods) {
+                val mutableMethod by lazy { mutableClass.findMutableMethodOf(method) }
                 val impl = method.implementation ?: continue
                 val instructions: List<Instruction> = impl.instructions.toList()
                 for ((index, insn) in instructions.withIndex()) {
@@ -258,7 +260,7 @@ val unlimitedCurrenciesPatch = bytecodePatch(
                             else -> continue
                         }
                         try {
-                            method.addInstructions(index, "mul-int/lit8 v$valueReg, v$valueReg, $mult")
+                            mutableMethod.addInstructions(index, "mul-int/lit8 v$valueReg, v$valueReg, $mult")
                             affectedCurrencies.add(keyValue!!)
                             patched++
                         } catch (_: Exception) {}
@@ -274,15 +276,15 @@ val unlimitedCurrenciesPatch = bytecodePatch(
                                     target in -32768..32767 -> "const/16 v$r, $target"
                                     else -> "const v$r, $target"
                                 }
-                                method.replaceInstruction(index, instr)
-                                method.replaceInstruction(index + 1, "nop")
+                                mutableMethod.replaceInstruction(index, instr)
+                                mutableMethod.replaceInstruction(index + 1, "nop")
                             } else {
                                 val instr = when {
                                     target in -32768..32767 -> "const/16 v0, $target"
                                     else -> "const v0, $target"
                                 }
-                                method.replaceInstruction(index, instr)
-                                method.replaceInstruction(index + 1, "move v$r, v0")
+                                mutableMethod.replaceInstruction(index, instr)
+                                mutableMethod.replaceInstruction(index + 1, "move v$r, v0")
                             }
                             affectedCurrencies.add(keyValue!!)
                             patched++
@@ -291,11 +293,11 @@ val unlimitedCurrenciesPatch = bytecodePatch(
                             val r = (next as OneRegisterInstruction).registerA
                             val hex = "0x" + target.toString(16)
                             if (r <= 0xff) {
-                                method.replaceInstruction(index, "const-wide/32 v$r, $hex")
-                                method.replaceInstruction(index + 1, "nop")
+                                mutableMethod.replaceInstruction(index, "const-wide/32 v$r, $hex")
+                                mutableMethod.replaceInstruction(index + 1, "nop")
                             } else {
-                                method.replaceInstruction(index, "const-wide/32 v0, $hex")
-                                method.replaceInstruction(index + 1, "move-wide v$r, v0")
+                                mutableMethod.replaceInstruction(index, "const-wide/32 v0, $hex")
+                                mutableMethod.replaceInstruction(index + 1, "move-wide v$r, v0")
                             }
                             affectedCurrencies.add(keyValue!!)
                             patched++
@@ -305,11 +307,11 @@ val unlimitedCurrenciesPatch = bytecodePatch(
                             val bits = java.lang.Float.floatToRawIntBits(target.toFloat())
                             val hex = "0x" + Integer.toHexString(bits)
                             if (r <= 0xff) {
-                                method.replaceInstruction(index, "const v$r, $hex")
-                                method.replaceInstruction(index + 1, "nop")
+                                mutableMethod.replaceInstruction(index, "const v$r, $hex")
+                                mutableMethod.replaceInstruction(index + 1, "nop")
                             } else {
-                                method.replaceInstruction(index, "const v0, $hex")
-                                method.replaceInstruction(index + 1, "move v$r, v0")
+                                mutableMethod.replaceInstruction(index, "const v0, $hex")
+                                mutableMethod.replaceInstruction(index + 1, "move v$r, v0")
                             }
                             affectedCurrencies.add(keyValue!!)
                             patched++
@@ -317,14 +319,14 @@ val unlimitedCurrenciesPatch = bytecodePatch(
                         isGetString && next.opcode == Opcode.MOVE_RESULT_OBJECT -> {
                             val r = (next as OneRegisterInstruction).registerA
                             if (r <= 0xff) {
-                                method.replaceInstruction(index, "const-string v$r, \"$target\"")
-                                method.replaceInstruction(index + 1, "nop")
+                                mutableMethod.replaceInstruction(index, "const-string v$r, \"$target\"")
+                                mutableMethod.replaceInstruction(index + 1, "nop")
                             } else if (r <= 0xffff) {
-                                method.replaceInstruction(index, "const-string/jumbo v$r, \"$target\"")
-                                method.replaceInstruction(index + 1, "nop")
+                                mutableMethod.replaceInstruction(index, "const-string/jumbo v$r, \"$target\"")
+                                mutableMethod.replaceInstruction(index + 1, "nop")
                             } else {
-                                method.replaceInstruction(index, "const-string v0, \"$target\"")
-                                method.replaceInstruction(index + 1, "move-object v$r, v0")
+                                mutableMethod.replaceInstruction(index, "const-string v0, \"$target\"")
+                                mutableMethod.replaceInstruction(index + 1, "move-object v$r, v0")
                             }
                             affectedCurrencies.add(keyValue!!)
                             patched++
@@ -332,14 +334,14 @@ val unlimitedCurrenciesPatch = bytecodePatch(
                         isHasKey && next.opcode == Opcode.MOVE_RESULT -> {
                             val r = (next as OneRegisterInstruction).registerA
                             if (r <= 0xf) {
-                                method.replaceInstruction(index, "const/4 v$r, 0x1")
-                                method.replaceInstruction(index + 1, "nop")
+                                mutableMethod.replaceInstruction(index, "const/4 v$r, 0x1")
+                                mutableMethod.replaceInstruction(index + 1, "nop")
                             } else if (r <= 0xff) {
-                                method.replaceInstruction(index, "const/16 v$r, 0x1")
-                                method.replaceInstruction(index + 1, "nop")
+                                mutableMethod.replaceInstruction(index, "const/16 v$r, 0x1")
+                                mutableMethod.replaceInstruction(index + 1, "nop")
                             } else {
-                                method.replaceInstruction(index, "const/4 v0, 0x1")
-                                method.replaceInstruction(index + 1, "move v$r, v0")
+                                mutableMethod.replaceInstruction(index, "const/4 v0, 0x1")
+                                mutableMethod.replaceInstruction(index + 1, "move v$r, v0")
                             }
                             affectedCurrencies.add(keyValue!!)
                             patched++

--- a/patches/src/main/kotlin/patches/universal/unlock/UnlockPremiumPatch.kt
+++ b/patches/src/main/kotlin/patches/universal/unlock/UnlockPremiumPatch.kt
@@ -6,6 +6,7 @@ import app.morphe.patcher.extensions.InstructionExtensions.replaceInstruction
 import app.morphe.patcher.patch.bytecodePatch
 import app.morphe.patcher.patch.stringOption
 import patches.universal.ads.util.cloneMutable
+import patches.universal.ads.util.findMutableMethodOf
 import com.android.tools.smali.dexlib2.Opcode
 import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
 import com.android.tools.smali.dexlib2.iface.reference.MethodReference
@@ -291,8 +292,8 @@ val unlockPremiumPatch = bytecodePatch(
             val tl = classDef.type.lowercase()
             if (!tl.contains("revenuecat") && !tl.contains("purchases")) return@classDefForEach
             if (tl.contains("okhttp") || tl.contains("ssl")) return@classDefForEach
-            val mutableClass = try { mutableClassDefBy(classDef) } catch (_: Exception) { return@classDefForEach }
-            for (method in mutableClass.methods) {
+            val mutableClass by lazy { try { mutableClassDefBy(classDef) } catch (_: Exception) { null } }
+            for (method in classDef.methods) {
                 if (method.returnType != "Z") continue
                 val n = method.name.lowercase()
                 if (n.contains("provider") || n.contains("product") || n.contains("progress")) continue
@@ -300,7 +301,8 @@ val unlockPremiumPatch = bytecodePatch(
                 if (!isEntitlementCheck) continue
                 try {
                     if (method.implementation == null) continue
-                    method.addInstructions(0, "const/4 v0, 0x1\nreturn v0")
+                    val mc = mutableClass ?: continue
+                    mc.findMutableMethodOf(method).addInstructions(0, "const/4 v0, 0x1\nreturn v0")
                     patched++
                     patchedMethods.add("RC:${method.name}")
                 } catch (_: Exception) {}
@@ -311,14 +313,15 @@ val unlockPremiumPatch = bytecodePatch(
         classDefForEach { classDef ->
             val tl = classDef.type.lowercase()
             if (!tl.contains("revenuecat") || !tl.contains("verification")) return@classDefForEach
-            val mutableClass = try { mutableClassDefBy(classDef) } catch (_: Exception) { return@classDefForEach }
-            for (method in mutableClass.methods) {
+            val mutableClass by lazy { try { mutableClassDefBy(classDef) } catch (_: Exception) { null } }
+            for (method in classDef.methods) {
                 if (method.returnType != "Z") continue
                 val n = method.name.lowercase()
                 if (n.contains("verify") || n.contains("enforced") || n.contains("informational")) {
                     try {
                         if (method.implementation == null) continue
-                        method.addInstructions(0, "const/4 v0, 0x1\nreturn v0")
+                        val mc = mutableClass ?: continue
+                        mc.findMutableMethodOf(method).addInstructions(0, "const/4 v0, 0x1\nreturn v0")
                         patched++
                         patchedMethods.add("RC:verify:${method.name}")
                     } catch (_: Exception) {}
@@ -459,22 +462,24 @@ val unlockPremiumPatch = bytecodePatch(
                             (m.name == "getValue" && m.returnType == "I" && activeConst.containsKey(classDef.type)))
                     }
                     if (!hasCandidate) return@classDefForEach
-                    val mutableClass = try { mutableClassDefBy(classDef) } catch (_: Exception) { return@classDefForEach }
-                    for (method in mutableClass.methods) {
+                    val mutableClass by lazy { try { mutableClassDefBy(classDef) } catch (_: Exception) { null } }
+                    for (method in classDef.methods) {
                         try {
                             if (method.implementation == null || method.parameterTypes.isNotEmpty()) continue
                             val ret = method.returnType
                             val activeField = activeConst[ret]
+                            val mc = mutableClass ?: continue
+                            val mutableMethod = mc.findMutableMethodOf(method)
                             if (activeField != null) {
                                 if (method.name == "values" || method.name == "valueOf" || method.name == "getEntries") continue
-                                method.addInstructions(0, "sget-object v0, $ret->$activeField:$ret\nreturn-object v0")
+                                mutableMethod.addInstructions(0, "sget-object v0, $ret->$activeField:$ret\nreturn-object v0")
                                 patched++
                                 patchedMethods.add("EnumStatus:${method.name}->$activeField")
                             } else if (method.name == "getValue" && ret == "I" && activeConst.containsKey(classDef.type)) {
                                 val intField = constIntField[classDef.type] ?: continue
                                 val enumType = classDef.type
                                 val field = activeConst[enumType] ?: continue
-                                method.addInstructions(0, "sget-object v0, $enumType->$field:$enumType\niget v0, v0, $enumType->$intField:I\nreturn v0")
+                                mutableMethod.addInstructions(0, "sget-object v0, $enumType->$field:$enumType\niget v0, v0, $enumType->$intField:I\nreturn v0")
                                 patched++
                                 patchedMethods.add("EnumStatus:getValue->$field")
                             }
@@ -525,10 +530,10 @@ val unlockPremiumPatch = bytecodePatch(
                 }
             }
 
-            val mutableClass = try { mutableClassDefBy(classDef) } catch (_: Exception) { return@classDefForEach }
+            val mutableClass by lazy { try { mutableClassDefBy(classDef) } catch (_: Exception) { null } }
 
             // 2a) Generic premium Z methods (hasPremiumAccess etc.) in this class
-            for (method in mutableClass.methods) {
+            for (method in classDef.methods) {
                 if (method.returnType != "Z") continue
                 val n = method.name.lowercase()
                 if (n.length < 3 || n.length > 40) continue
@@ -539,8 +544,8 @@ val unlockPremiumPatch = bytecodePatch(
                 if (n == "ispro" || n == "haspro" || n == "isprouser" || n == "hasprouser" || n.contains("premium")) {
                     try {
                         if (method.implementation == null) continue
-                        // avoid double-patching if already patched via Fingerprint
-                        method.addInstructions(0, "const/4 v0, 0x1\nreturn v0")
+                        val mc = mutableClass ?: continue
+                        mc.findMutableMethodOf(method).addInstructions(0, "const/4 v0, 0x1\nreturn v0")
                         patched++
                         patchedMethods.add("Generic:${method.name}")
                     } catch (_: Exception) {}
@@ -548,7 +553,8 @@ val unlockPremiumPatch = bytecodePatch(
             }
 
             // 2b) Prefs/DataStore getBoolean/getInt/contains -> premium keys
-            for (method in mutableClass.methods) {
+            for (method in classDef.methods) {
+                val mutableMethod by lazy { mutableClass?.findMutableMethodOf(method) }
                 val impl = method.implementation ?: continue
                 val instructions = impl.instructions.toList()
                 for ((index, insn) in instructions.withIndex()) {
@@ -601,18 +607,19 @@ val unlockPremiumPatch = bytecodePatch(
                     if (keyValue == null || !isPremiumKey(keyValue!!.lowercase())) continue
 
                     val next = instructions.getOrNull(index + 1) ?: continue
+                    val mm = mutableMethod ?: continue
                     when {
                         isGetBoolean && next.opcode == Opcode.MOVE_RESULT -> {
                             val r = (next as com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction).registerA
                             if (r <= 0xf) {
-                                method.replaceInstruction(index, "const/4 v$r, 0x1")
-                                method.replaceInstruction(index + 1, "nop")
+                                mm.replaceInstruction(index, "const/4 v$r, 0x1")
+                                mm.replaceInstruction(index + 1, "nop")
                             } else if (r <= 0xff) {
-                                method.replaceInstruction(index, "const/16 v$r, 0x1")
-                                method.replaceInstruction(index + 1, "nop")
+                                mm.replaceInstruction(index, "const/16 v$r, 0x1")
+                                mm.replaceInstruction(index + 1, "nop")
                             } else {
-                                method.replaceInstruction(index, "const/4 v0, 0x1")
-                                method.replaceInstruction(index + 1, "move v$r, v0")
+                                mm.replaceInstruction(index, "const/4 v0, 0x1")
+                                mm.replaceInstruction(index + 1, "move v$r, v0")
                             }
                             patchedMethods.add("Prefs:${keyValue}:getBoolean")
                             patched++
@@ -620,14 +627,14 @@ val unlockPremiumPatch = bytecodePatch(
                         isHasKey && next.opcode == Opcode.MOVE_RESULT -> {
                             val r = (next as com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction).registerA
                             if (r <= 0xf) {
-                                method.replaceInstruction(index, "const/4 v$r, 0x1")
-                                method.replaceInstruction(index + 1, "nop")
+                                mm.replaceInstruction(index, "const/4 v$r, 0x1")
+                                mm.replaceInstruction(index + 1, "nop")
                             } else if (r <= 0xff) {
-                                method.replaceInstruction(index, "const/16 v$r, 0x1")
-                                method.replaceInstruction(index + 1, "nop")
+                                mm.replaceInstruction(index, "const/16 v$r, 0x1")
+                                mm.replaceInstruction(index + 1, "nop")
                             } else {
-                                method.replaceInstruction(index, "const/4 v0, 0x1")
-                                method.replaceInstruction(index + 1, "move v$r, v0")
+                                mm.replaceInstruction(index, "const/4 v0, 0x1")
+                                mm.replaceInstruction(index + 1, "move v$r, v0")
                             }
                             patchedMethods.add("Prefs:${keyValue}:contains")
                             patched++
@@ -635,14 +642,14 @@ val unlockPremiumPatch = bytecodePatch(
                         isGetInt && next.opcode == Opcode.MOVE_RESULT -> {
                             val r = (next as com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction).registerA
                             if (r <= 0xf) {
-                                method.replaceInstruction(index, "const/4 v$r, 0x1")
-                                method.replaceInstruction(index + 1, "nop")
+                                mm.replaceInstruction(index, "const/4 v$r, 0x1")
+                                mm.replaceInstruction(index + 1, "nop")
                             } else if (r <= 0xff) {
-                                method.replaceInstruction(index, "const/16 v$r, 0x1")
-                                method.replaceInstruction(index + 1, "nop")
+                                mm.replaceInstruction(index, "const/16 v$r, 0x1")
+                                mm.replaceInstruction(index + 1, "nop")
                             } else {
-                                method.replaceInstruction(index, "const/4 v0, 0x1")
-                                method.replaceInstruction(index + 1, "move v$r, v0")
+                                mm.replaceInstruction(index, "const/4 v0, 0x1")
+                                mm.replaceInstruction(index + 1, "move v$r, v0")
                             }
                             patchedMethods.add("Prefs:${keyValue}:getInt")
                             patched++
@@ -650,11 +657,11 @@ val unlockPremiumPatch = bytecodePatch(
                         isGetLong && next.opcode == Opcode.MOVE_RESULT_WIDE -> {
                             val r = (next as com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction).registerA
                             if (r <= 0xff) {
-                                method.replaceInstruction(index, "const-wide/16 v$r, 0x1")
-                                method.replaceInstruction(index + 1, "nop")
+                                mm.replaceInstruction(index, "const-wide/16 v$r, 0x1")
+                                mm.replaceInstruction(index + 1, "nop")
                             } else {
-                                method.replaceInstruction(index, "const-wide/16 v0, 0x1")
-                                method.replaceInstruction(index + 1, "move-wide v$r, v0")
+                                mm.replaceInstruction(index, "const-wide/16 v0, 0x1")
+                                mm.replaceInstruction(index + 1, "move-wide v$r, v0")
                             }
                             patchedMethods.add("Prefs:${keyValue}:getLong")
                             patched++
@@ -662,14 +669,14 @@ val unlockPremiumPatch = bytecodePatch(
                         isGetString && next.opcode == Opcode.MOVE_RESULT_OBJECT -> {
                             val r = (next as com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction).registerA
                             if (r <= 0xff) {
-                                method.replaceInstruction(index, "const-string v$r, \"premium\"")
-                                method.replaceInstruction(index + 1, "nop")
+                                mm.replaceInstruction(index, "const-string v$r, \"premium\"")
+                                mm.replaceInstruction(index + 1, "nop")
                             } else if (r <= 0xffff) {
-                                method.replaceInstruction(index, "const-string/jumbo v$r, \"premium\"")
-                                method.replaceInstruction(index + 1, "nop")
+                                mm.replaceInstruction(index, "const-string/jumbo v$r, \"premium\"")
+                                mm.replaceInstruction(index + 1, "nop")
                             } else {
-                                method.replaceInstruction(index, "const-string v0, \"premium\"")
-                                method.replaceInstruction(index + 1, "move-object v$r, v0")
+                                mm.replaceInstruction(index, "const-string v0, \"premium\"")
+                                mm.replaceInstruction(index + 1, "move-object v$r, v0")
                             }
                             patchedMethods.add("Prefs:${keyValue}:getString")
                             patched++
@@ -682,7 +689,7 @@ val unlockPremiumPatch = bytecodePatch(
                             }
                             if (valueReg == null) continue
                             try {
-                                method.addInstructions(index, "const/4 v$valueReg, 0x1")
+                                mm.addInstructions(index, "const/4 v$valueReg, 0x1")
                                 patchedMethods.add("Prefs:${keyValue}:putBoolean->true")
                                 patched++
                             } catch (_: Exception) {}
@@ -698,9 +705,9 @@ val unlockPremiumPatch = bytecodePatch(
                                 // for sku_cache_price_premium, put a fake price
                                 val fakePrice = if (keyValue!!.contains("price")) "9.99" else "premium"
                                 if (valueReg <= 0xff) {
-                                    method.addInstructions(index, "const-string v$valueReg, \"$fakePrice\"")
+                                    mm.addInstructions(index, "const-string v$valueReg, \"$fakePrice\"")
                                 } else {
-                                    method.addInstructions(index, "const-string v0, \"$fakePrice\"\nmove-object v$valueReg, v0")
+                                    mm.addInstructions(index, "const-string v0, \"$fakePrice\"\nmove-object v$valueReg, v0")
                                 }
                                 patchedMethods.add("Prefs:${keyValue}:putString")
                                 patched++

--- a/patches/src/main/kotlin/patches/universal/update/BypassForcedUpdatesPatch.kt
+++ b/patches/src/main/kotlin/patches/universal/update/BypassForcedUpdatesPatch.kt
@@ -7,6 +7,7 @@ import app.morphe.patcher.patch.bytecodePatch
 import com.android.tools.smali.dexlib2.Opcode
 import com.android.tools.smali.dexlib2.builder.instruction.BuilderInstruction35c
 import com.android.tools.smali.dexlib2.builder.instruction.BuilderInstruction3rc
+import com.android.tools.smali.dexlib2.iface.Method
 import com.android.tools.smali.dexlib2.iface.instruction.NarrowLiteralInstruction
 import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
 import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
@@ -15,6 +16,7 @@ import com.android.tools.smali.dexlib2.iface.reference.StringReference
 import java.util.Locale
 import java.util.logging.Logger
 import patches.universal.ads.AppUpdateManagerImplStartUpdateFlowFingerprint
+import patches.universal.ads.util.findMutableMethodOf
 
 private val updateTerms = listOf(
     "update required",
@@ -59,7 +61,7 @@ private fun String.normalized() = lowercase(Locale.ROOT)
 private fun MethodReference.isVoidCall(name: String): Boolean =
     this.name == name && returnType == "V"
 
-private fun methodEvidence(method: app.morphe.patcher.util.proxy.mutableTypes.MutableMethod): Evidence {
+private fun methodEvidence(method: Method): Evidence {
     val implementation = method.implementation ?: return Evidence()
     val strings = implementation.instructions.mapNotNull { instruction ->
         ((instruction as? ReferenceInstruction)?.reference as? StringReference)?.string
@@ -175,13 +177,14 @@ val bypassForcedUpdatesPatch = bytecodePatch(
         }
 
         classDefForEach { classDef ->
-            val mutableClass = mutableClassDefBy(classDef)
-            for (method in mutableClass.methods) {
+            val mutableClass by lazy { mutableClassDefBy(classDef) }
+            for (method in classDef.methods) {
+                val mutableMethod by lazy { mutableClass.findMutableMethodOf(method) }
                 val implementation = method.implementation ?: continue
                 val evidence = methodEvidence(method)
                 if (evidence.score < 4) continue
 
-                if (bypassUpdateGate == true && falseBooleanGate(method, evidence)) {
+                if (bypassUpdateGate == true && falseBooleanGate(mutableMethod, evidence)) {
                     gates++
                     continue
                 }
@@ -199,7 +202,7 @@ val bypassForcedUpdatesPatch = bytecodePatch(
                         val register = booleanArgumentRegister(instruction)
                         val previous = instructions.getOrNull(index - 1)
                         if (register != null && isFalseConstant(previous, register)) {
-                            method.replaceInstruction(index - 1, "const/4 v$register, 0x1")
+                            mutableMethod.replaceInstruction(index - 1, "const/4 v$register, 0x1")
                             dialogs++
                         }
                     }
@@ -211,7 +214,7 @@ val bypassForcedUpdatesPatch = bytecodePatch(
                                 reference.isVoidCall("finishAndRemoveTask"))) ||
                             (reference.definingClass == "Ljava/lang/System;" && reference.isVoidCall("exit")))
                     ) {
-                        method.replaceInstruction(index, "nop")
+                        mutableMethod.replaceInstruction(index, "nop")
                         exits++
                     }
 
@@ -220,7 +223,7 @@ val bypassForcedUpdatesPatch = bytecodePatch(
                         reference.name in setOf("startActivity", "startActivityForResult") &&
                         reference.returnType == "V"
                     ) {
-                        method.replaceInstruction(index, "nop")
+                        mutableMethod.replaceInstruction(index, "nop")
                         redirects++
                     }
                 }


### PR DESCRIPTION
<!-- One logical change per PR. Add one new patch or one enhancement. See CONTRIBUTING.md -->
## What does this PR do?

Fixes out of memory errors while patching by using `mutableClassDefBy` only when required.

Also cleans up some usage of `RegisterRangeInstruction` with a few more morphe-patches-library functions that `cloneParameters()` also came from.

<!-- feat: add Foo patch / fix: handle Bar edge. Use one line per commit -->

## Checklist

- [x] Single feature (one new patch *or* one enhancement, not 5 bundled)
- [x] Conventional commits (`feat:`, `fix:`, `chore:`) — no `move`/`update`/`hi`
- [x] Feature branch, not `main` (`git checkout -b feat/foo`)
- [x] No generated files in diff: `patches-list.json`, `patches-bundle.json`, `CHANGELOG.md`, `gradle.properties` version, `.releaserc`, `gradlew`
- [x] `.\gradlew.bat :patches:build` → `BUILD SUCCESSFUL`
- [x] `.\gradlew.bat :patches:generatePatchesList` → literal `Select-String -SimpleMatch '"Your Patch Name"'` found, then `git checkout -- patches-list.json`

## Testing

<!-- APK package + patch options tested, Morphe log excerpt if relevant -->

Only briefly tested but should not cause any problems.
